### PR TITLE
Bump some vulnerable dependencies; base on distroless/static

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# We need a shell for a lot of redirection/piping to work
-defaultBaseImage: gcr.io/distroless/base:debug-nonroot
-
 builds:
 - id: policy-controller
   dir: .

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/hashicorp/go-version v1.5.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/vault/sdk v0.5.0
+	github.com/hashicorp/vault/sdk v0.5.1
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/letsencrypt/boulder v0.0.0-20220331220046-b23ab962616e
@@ -47,10 +47,10 @@ require (
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
 	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.21.0
-	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/net v0.0.0-20220607020251-c690dde0001d
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
-	golang.org/x/time v0.0.0-20220411224347-583f2d630306
+	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68
+	golang.org/x/time v0.0.0-20220609170525-579cf78fd858
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/square/go-jose.v2 v2.6.0
@@ -184,7 +184,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
-	github.com/hashicorp/vault/api v1.5.0 // indirect
+	github.com/hashicorp/vault/api v1.7.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/in-toto/in-toto-golang v0.3.4-0.20211211042327-af1f9fb822bf // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -286,7 +286,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/api v0.83.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8 // indirect
+	google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac // indirect
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1383,10 +1383,14 @@ github.com/hashicorp/vault/api v1.3.0/go.mod h1:EabNQLI0VWbWoGlA+oBLC8PXmR9D60aU
 github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
 github.com/hashicorp/vault/api v1.5.0 h1:Bp6yc2bn7CWkOrVIzFT/Qurzx528bdavF3nz590eu28=
 github.com/hashicorp/vault/api v1.5.0/go.mod h1:LkMdrZnWNrFaQyYYazWVn7KshilfDidgVBq6YiTq/bM=
+github.com/hashicorp/vault/api v1.7.1 h1:uUpxcZO3XV1Sb96dEtT+tZlSpV7U/zEi0NoksM7lU5M=
+github.com/hashicorp/vault/api v1.7.1/go.mod h1:TlKWwxZySuDARVFz/H0sf6rgWddIlX4t4DO9baT2nXc=
 github.com/hashicorp/vault/sdk v0.3.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
 github.com/hashicorp/vault/sdk v0.4.1/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
 github.com/hashicorp/vault/sdk v0.5.0 h1:EED7p0OCU3OY5SAqJwSANofY1YKMytm+jDHDQ2EzGVQ=
 github.com/hashicorp/vault/sdk v0.5.0/go.mod h1:UJZHlfwj7qUJG8g22CuxUgkdJouFrBNvBHCyx8XAPdo=
+github.com/hashicorp/vault/sdk v0.5.1 h1:zly/TmNgOXCGgWIRA8GojyXzG817POtVh3uzIwzZx+8=
+github.com/hashicorp/vault/sdk v0.5.1/go.mod h1:DoGraE9kKGNcVgPmTuX357Fm6WAx1Okvde8Vp3dPDoU=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 h1:xixZ2bWeofWV68J+x6AzmKuVM/JWCQwkWm6GW/MUR6I=
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
@@ -2489,6 +2493,8 @@ golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -2825,6 +2831,8 @@ golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 h1:z8Hj/bl9cOV2grsOpEaQFUaly0JWN3i97mo3jXKJNp0=
+golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -2853,6 +2861,8 @@ golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20220224211638-0e9765cccd65/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220411224347-583f2d630306 h1:+gHMid33q6pen7kv9xvT+JRinntgeXO2AeZVd0AWD3w=
 golang.org/x/time v0.0.0-20220411224347-583f2d630306/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20220609170525-579cf78fd858 h1:Dpdu/EMxGMFgq0CeYMh4fazTD2vtlZRYE7wyynxJb9U=
+golang.org/x/time v0.0.0-20220609170525-579cf78fd858/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -3177,6 +3187,8 @@ google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8 h1:qRu95HZ148xXw+XeZ3dvqe85PxH4X8+jIo0iRPKcEnM=
 google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8/go.mod h1:yKyY4AMRwFiC8yMMNaMi+RkCnjZJt9LoWuvhXjMs+To=
+google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac h1:ByeiW1F67iV9o8ipGskA+HWzSkMbRJuKLlwCdPxzn7A=
+google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=

--- a/go.sum
+++ b/go.sum
@@ -1381,13 +1381,11 @@ github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/vault/api v1.3.0/go.mod h1:EabNQLI0VWbWoGlA+oBLC8PXmR9D60aUVgQGvangFWQ=
 github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
-github.com/hashicorp/vault/api v1.5.0 h1:Bp6yc2bn7CWkOrVIzFT/Qurzx528bdavF3nz590eu28=
 github.com/hashicorp/vault/api v1.5.0/go.mod h1:LkMdrZnWNrFaQyYYazWVn7KshilfDidgVBq6YiTq/bM=
 github.com/hashicorp/vault/api v1.7.1 h1:uUpxcZO3XV1Sb96dEtT+tZlSpV7U/zEi0NoksM7lU5M=
 github.com/hashicorp/vault/api v1.7.1/go.mod h1:TlKWwxZySuDARVFz/H0sf6rgWddIlX4t4DO9baT2nXc=
 github.com/hashicorp/vault/sdk v0.3.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
 github.com/hashicorp/vault/sdk v0.4.1/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
-github.com/hashicorp/vault/sdk v0.5.0 h1:EED7p0OCU3OY5SAqJwSANofY1YKMytm+jDHDQ2EzGVQ=
 github.com/hashicorp/vault/sdk v0.5.0/go.mod h1:UJZHlfwj7qUJG8g22CuxUgkdJouFrBNvBHCyx8XAPdo=
 github.com/hashicorp/vault/sdk v0.5.1 h1:zly/TmNgOXCGgWIRA8GojyXzG817POtVh3uzIwzZx+8=
 github.com/hashicorp/vault/sdk v0.5.1/go.mod h1:DoGraE9kKGNcVgPmTuX357Fm6WAx1Okvde8Vp3dPDoU=
@@ -2491,7 +2489,6 @@ golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -2829,7 +2826,6 @@ golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 h1:z8Hj/bl9cOV2grsOpEaQFUaly0JWN3i97mo3jXKJNp0=
 golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2859,7 +2855,6 @@ golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220224211638-0e9765cccd65/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20220411224347-583f2d630306 h1:+gHMid33q6pen7kv9xvT+JRinntgeXO2AeZVd0AWD3w=
 golang.org/x/time v0.0.0-20220411224347-583f2d630306/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220609170525-579cf78fd858 h1:Dpdu/EMxGMFgq0CeYMh4fazTD2vtlZRYE7wyynxJb9U=
 golang.org/x/time v0.0.0-20220609170525-579cf78fd858/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -3185,7 +3180,6 @@ google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
-google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8 h1:qRu95HZ148xXw+XeZ3dvqe85PxH4X8+jIo0iRPKcEnM=
 google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8/go.mod h1:yKyY4AMRwFiC8yMMNaMi+RkCnjZJt9LoWuvhXjMs+To=
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac h1:ByeiW1F67iV9o8ipGskA+HWzSkMbRJuKLlwCdPxzn7A=
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/auth.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/auth.go
@@ -31,16 +31,82 @@ func (a *Auth) Login(ctx context.Context, authMethod AuthMethod) (*Secret, error
 	if authMethod == nil {
 		return nil, fmt.Errorf("no auth method provided for login")
 	}
+	return a.login(ctx, authMethod)
+}
 
-	authSecret, err := authMethod.Login(ctx, a.c)
+// MFALogin is a wrapper that helps satisfy Vault's MFA implementation.
+// If optional credentials are provided a single-phase login will be attempted
+// and the resulting Secret will contain a ClientToken if the authentication is successful.
+// The client's token will also be set accordingly.
+//
+// If no credentials are provided a two-phase MFA login will be assumed and the resulting
+// Secret will have a MFARequirement containing the MFARequestID to be used in a follow-up
+// call to `sys/mfa/validate` or by passing it to the method (*Auth).MFAValidate.
+func (a *Auth) MFALogin(ctx context.Context, authMethod AuthMethod, creds ...string) (*Secret, error) {
+	if len(creds) > 0 {
+		a.c.SetMFACreds(creds)
+		return a.login(ctx, authMethod)
+	}
+
+	return a.twoPhaseMFALogin(ctx, authMethod)
+}
+
+// MFAValidate validates an MFA request using the appropriate payload and a secret containing
+// Auth.MFARequirement, like the one returned by MFALogin when credentials are not provided.
+// Upon successful validation the client token will be set accordingly.
+//
+// The Secret returned is the authentication secret, which if desired can be
+// passed as input to the NewLifetimeWatcher method in order to start
+// automatically renewing the token.
+func (a *Auth) MFAValidate(ctx context.Context, mfaSecret *Secret, payload map[string]interface{}) (*Secret, error) {
+	if mfaSecret == nil || mfaSecret.Auth == nil || mfaSecret.Auth.MFARequirement == nil {
+		return nil, fmt.Errorf("secret does not contain MFARequirements")
+	}
+
+	s, err := a.c.Sys().MFAValidateWithContext(ctx, mfaSecret.Auth.MFARequirement.GetMFARequestID(), payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.checkAndSetToken(s)
+}
+
+// login performs the (*AuthMethod).Login() with the configured client and checks that a ClientToken is returned
+func (a *Auth) login(ctx context.Context, authMethod AuthMethod) (*Secret, error) {
+	s, err := authMethod.Login(ctx, a.c)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in to auth method: %w", err)
 	}
-	if authSecret == nil || authSecret.Auth == nil || authSecret.Auth.ClientToken == "" {
-		return nil, fmt.Errorf("login response from auth method did not return client token")
+
+	return a.checkAndSetToken(s)
+}
+
+// twoPhaseMFALogin performs the (*AuthMethod).Login() with the configured client
+// and checks that an MFARequirement is returned
+func (a *Auth) twoPhaseMFALogin(ctx context.Context, authMethod AuthMethod) (*Secret, error) {
+	s, err := authMethod.Login(ctx, a.c)
+	if err != nil {
+		return nil, fmt.Errorf("unable to log in: %w", err)
+	}
+	if s == nil || s.Auth == nil || s.Auth.MFARequirement == nil {
+		if s != nil {
+			s.Warnings = append(s.Warnings, "expected secret to contain MFARequirements")
+		}
+		return s, fmt.Errorf("assumed two-phase MFA login, returned secret is missing MFARequirements")
 	}
 
-	a.c.SetToken(authSecret.Auth.ClientToken)
+	return s, nil
+}
 
-	return authSecret, nil
+func (a *Auth) checkAndSetToken(s *Secret) (*Secret, error) {
+	if s == nil || s.Auth == nil || s.Auth.ClientToken == "" {
+		if s != nil {
+			s.Warnings = append(s.Warnings, "expected secret to contain ClientToken")
+		}
+		return s, fmt.Errorf("response did not return ClientToken, client token not set")
+	}
+
+	a.c.SetToken(s.Auth.ClientToken)
+
+	return s, nil
 }

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/kv.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/kv.go
@@ -1,0 +1,50 @@
+package api
+
+// A KVSecret is a key-value secret returned by Vault's KV secrets engine,
+// and is the most basic type of secret stored in Vault.
+//
+// Data contains the key-value pairs of the secret itself,
+// while Metadata contains a subset of metadata describing
+// this particular version of the secret.
+// The Metadata field for a KV v1 secret will always be nil, as
+// metadata is only supported starting in KV v2.
+//
+// The Raw field can be inspected for information about the lease,
+// and passed to a LifetimeWatcher object for periodic renewal.
+type KVSecret struct {
+	Data            map[string]interface{}
+	VersionMetadata *KVVersionMetadata
+	CustomMetadata  map[string]interface{}
+	Raw             *Secret
+}
+
+// KVv1 is used to return a client for reads and writes against
+// a KV v1 secrets engine in Vault.
+//
+// The mount path is the location where the target KV secrets engine resides
+// in Vault.
+//
+// While v1 is not necessarily deprecated, Vault development servers tend to
+// use v2 as the version of the KV secrets engine, as this is what's mounted
+// by default when a server is started in -dev mode. See the kvv2 struct.
+//
+// Learn more about the KV secrets engine here:
+// https://www.vaultproject.io/docs/secrets/kv
+func (c *Client) KVv1(mountPath string) *KVv1 {
+	return &KVv1{c: c, mountPath: mountPath}
+}
+
+// KVv2 is used to return a client for reads and writes against
+// a KV v2 secrets engine in Vault.
+//
+// The mount path is the location where the target KV secrets engine resides
+// in Vault.
+//
+// Vault development servers tend to have "secret" as the mount path,
+// as these are the default settings when a server is started in -dev mode.
+//
+// Learn more about the KV secrets engine here:
+// https://www.vaultproject.io/docs/secrets/kv
+func (c *Client) KVv2(mountPath string) *KVv2 {
+	return &KVv2{c: c, mountPath: mountPath}
+}

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/kv_v1.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/kv_v1.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"context"
+	"fmt"
+)
+
+type KVv1 struct {
+	c         *Client
+	mountPath string
+}
+
+// Get returns a secret from the KV v1 secrets engine.
+func (kv *KVv1) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
+	pathToRead := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
+
+	secret, err := kv.c.Logical().ReadWithContext(ctx, pathToRead)
+	if err != nil {
+		return nil, fmt.Errorf("error encountered while reading secret at %s: %w", pathToRead, err)
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("no secret found at %s", pathToRead)
+	}
+
+	return &KVSecret{
+		Data:            secret.Data,
+		VersionMetadata: nil,
+		Raw:             secret,
+	}, nil
+}
+
+// Put inserts a key-value secret (e.g. {"password": "Hashi123"}) into the
+// KV v1 secrets engine.
+//
+// If the secret already exists, it will be overwritten.
+func (kv *KVv1) Put(ctx context.Context, secretPath string, data map[string]interface{}) error {
+	pathToWriteTo := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
+
+	_, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, data)
+	if err != nil {
+		return fmt.Errorf("error writing secret to %s: %w", pathToWriteTo, err)
+	}
+
+	return nil
+}
+
+// Delete deletes a secret from the KV v1 secrets engine.
+func (kv *KVv1) Delete(ctx context.Context, secretPath string) error {
+	pathToDelete := fmt.Sprintf("%s/%s", kv.mountPath, secretPath)
+
+	_, err := kv.c.Logical().DeleteWithContext(ctx, pathToDelete)
+	if err != nil {
+		return fmt.Errorf("error deleting secret at %s: %w", pathToDelete, err)
+	}
+
+	return nil
+}

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/kv_v2.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/kv_v2.go
@@ -1,0 +1,788 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+type KVv2 struct {
+	c         *Client
+	mountPath string
+}
+
+// KVMetadata is the full metadata for a given KV v2 secret.
+type KVMetadata struct {
+	CASRequired        bool                   `mapstructure:"cas_required"`
+	CreatedTime        time.Time              `mapstructure:"created_time"`
+	CurrentVersion     int                    `mapstructure:"current_version"`
+	CustomMetadata     map[string]interface{} `mapstructure:"custom_metadata"`
+	DeleteVersionAfter time.Duration          `mapstructure:"delete_version_after"`
+	MaxVersions        int                    `mapstructure:"max_versions"`
+	OldestVersion      int                    `mapstructure:"oldest_version"`
+	UpdatedTime        time.Time              `mapstructure:"updated_time"`
+	// Keys are stringified ints, e.g. "3". To get a sorted slice of version metadata, use GetVersionsAsList.
+	Versions map[string]KVVersionMetadata `mapstructure:"versions"`
+	Raw      *Secret
+}
+
+// KVMetadataPutInput is the subset of metadata that can be replaced for a
+// KV v2 secret using the PutMetadata method.
+//
+// All fields should be explicitly provided, as any fields left unset in the
+// struct will be reset to their zero value.
+type KVMetadataPutInput struct {
+	CASRequired        bool
+	CustomMetadata     map[string]interface{}
+	DeleteVersionAfter time.Duration
+	MaxVersions        int
+}
+
+// KVMetadataPatchInput is the subset of metadata that can be manually modified for
+// a KV v2 secret using the PatchMetadata method.
+//
+// The struct's fields are all pointers. A pointer to a field's zero
+// value (e.g. false for *bool) implies that field should be reset to its
+// zero value after update, whereas a field left as a nil pointer
+// (e.g. nil for *bool) implies the field should remain unchanged.
+//
+// Since maps are already pointers, use an empty map to remove all
+// custom metadata.
+type KVMetadataPatchInput struct {
+	CASRequired        *bool
+	CustomMetadata     map[string]interface{}
+	DeleteVersionAfter *time.Duration
+	MaxVersions        *int
+}
+
+// KVVersionMetadata is a subset of metadata for a given version of a KV v2 secret.
+type KVVersionMetadata struct {
+	Version      int       `mapstructure:"version"`
+	CreatedTime  time.Time `mapstructure:"created_time"`
+	DeletionTime time.Time `mapstructure:"deletion_time"`
+	Destroyed    bool      `mapstructure:"destroyed"`
+}
+
+// Currently supported options: WithOption, WithCheckAndSet, WithMethod
+type KVOption func() (key string, value interface{})
+
+const (
+	KVOptionCheckAndSet    = "cas"
+	KVOptionMethod         = "method"
+	KVMergeMethodPatch     = "patch"
+	KVMergeMethodReadWrite = "rw"
+)
+
+// WithOption can optionally be passed to provide generic options for a
+// KV request. Valid keys and values depend on the type of request.
+func WithOption(key string, value interface{}) KVOption {
+	return func() (string, interface{}) {
+		return key, value
+	}
+}
+
+// WithCheckAndSet can optionally be passed to perform a check-and-set
+// operation on a KV request. If not set, the write will be allowed.
+// If cas is set to 0, a write will only be allowed if the key doesn't exist.
+// If set to non-zero, the write will only be allowed if the key’s current
+// version matches the version specified in the cas parameter.
+func WithCheckAndSet(cas int) KVOption {
+	return WithOption(KVOptionCheckAndSet, cas)
+}
+
+// WithMergeMethod can optionally be passed to dictate which type of
+// patch to perform in a Patch request. If set to "patch", then an HTTP PATCH
+// request will be issued. If set to "rw", then a read will be performed,
+// then a local update, followed by a remote update. Defaults to "patch".
+func WithMergeMethod(method string) KVOption {
+	return WithOption(KVOptionMethod, method)
+}
+
+// Get returns the latest version of a secret from the KV v2 secrets engine.
+//
+// If the latest version has been deleted, an error will not be thrown, but
+// the Data field on the returned secret will be nil, and the Metadata field
+// will contain the deletion time.
+func (kv *KVv2) Get(ctx context.Context, secretPath string) (*KVSecret, error) {
+	pathToRead := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
+
+	secret, err := kv.c.Logical().ReadWithContext(ctx, pathToRead)
+	if err != nil {
+		return nil, fmt.Errorf("error encountered while reading secret at %s: %w", pathToRead, err)
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("no secret found at %s", pathToRead)
+	}
+
+	kvSecret, err := extractDataAndVersionMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing secret at %s: %w", pathToRead, err)
+	}
+
+	cm, err := extractCustomMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("error reading custom metadata for secret at %s: %w", pathToRead, err)
+	}
+	kvSecret.CustomMetadata = cm
+
+	return kvSecret, nil
+}
+
+// GetVersion returns the data and metadata for a specific version of the
+// given secret.
+//
+// If that version has been deleted, the Data field on the
+// returned secret will be nil, and the Metadata field will contain the deletion time.
+//
+// GetVersionsAsList can provide a list of available versions sorted by
+// version number, while the response from GetMetadata contains them as a map.
+func (kv *KVv2) GetVersion(ctx context.Context, secretPath string, version int) (*KVSecret, error) {
+	pathToRead := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
+
+	queryParams := map[string][]string{"version": {strconv.Itoa(version)}}
+	secret, err := kv.c.Logical().ReadWithDataWithContext(ctx, pathToRead, queryParams)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("no secret with version %d found at %s", version, pathToRead)
+	}
+
+	kvSecret, err := extractDataAndVersionMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing secret at %s: %w", pathToRead, err)
+	}
+
+	cm, err := extractCustomMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("error reading custom metadata for secret at %s: %w", pathToRead, err)
+	}
+	kvSecret.CustomMetadata = cm
+
+	return kvSecret, nil
+}
+
+// GetVersionsAsList returns a subset of the metadata for each version of the secret, sorted by version number.
+func (kv *KVv2) GetVersionsAsList(ctx context.Context, secretPath string) ([]KVVersionMetadata, error) {
+	pathToRead := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
+
+	secret, err := kv.c.Logical().ReadWithContext(ctx, pathToRead)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, fmt.Errorf("no secret metadata found at %s", pathToRead)
+	}
+
+	md, err := extractFullMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract metadata from secret to determine versions: %w", err)
+	}
+
+	versionsList := make([]KVVersionMetadata, 0, len(md.Versions))
+	for _, versionMetadata := range md.Versions {
+		versionsList = append(versionsList, versionMetadata)
+	}
+
+	sort.Slice(versionsList, func(i, j int) bool { return versionsList[i].Version < versionsList[j].Version })
+	return versionsList, nil
+}
+
+// GetMetadata returns the full metadata for a given secret, including a map of
+// its existing versions and their respective creation/deletion times, etc.
+func (kv *KVv2) GetMetadata(ctx context.Context, secretPath string) (*KVMetadata, error) {
+	pathToRead := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
+
+	secret, err := kv.c.Logical().ReadWithContext(ctx, pathToRead)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Data == nil {
+		return nil, fmt.Errorf("no secret metadata found at %s", pathToRead)
+	}
+
+	md, err := extractFullMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract metadata from secret: %w", err)
+	}
+
+	return md, nil
+}
+
+// Put inserts a key-value secret (e.g. {"password": "Hashi123"})
+// into the KV v2 secrets engine.
+//
+// If the secret already exists, a new version will be created
+// and the previous version can be accessed with the GetVersion method.
+// GetMetadata can provide a list of available versions.
+func (kv *KVv2) Put(ctx context.Context, secretPath string, data map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
+	pathToWriteTo := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
+
+	wrappedData := map[string]interface{}{
+		"data": data,
+	}
+
+	// Add options such as check-and-set, etc.
+	// We leave this as an optional arg so that most users
+	// can just pass plain key-value secret data without
+	// having to remember to put the extra layer "data" in there.
+	options := make(map[string]interface{})
+	for _, opt := range opts {
+		k, v := opt()
+		options[k] = v
+	}
+	if len(opts) > 0 {
+		wrappedData["options"] = options
+	}
+
+	secret, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, wrappedData)
+	if err != nil {
+		return nil, fmt.Errorf("error writing secret to %s: %w", pathToWriteTo, err)
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("no secret was written to %s", pathToWriteTo)
+	}
+
+	metadata, err := extractVersionMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("secret was written successfully, but unable to view version metadata from response: %w", err)
+	}
+
+	kvSecret := &KVSecret{
+		Data:            nil, // secret.Data in this case is the metadata
+		VersionMetadata: metadata,
+		Raw:             secret,
+	}
+
+	cm, err := extractCustomMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("error reading custom metadata for secret at %s: %w", pathToWriteTo, err)
+	}
+	kvSecret.CustomMetadata = cm
+
+	return kvSecret, nil
+}
+
+// PutMetadata can be used to fully replace a subset of metadata fields for a
+// given KV v2 secret. All fields will replace the corresponding values on the Vault server.
+// Any fields left as nil will reset the field on the Vault server back to its zero value.
+//
+// To only partially replace the values of these metadata fields, use PatchMetadata.
+//
+// This method can also be used to create a new secret with just metadata and no secret data yet.
+func (kv *KVv2) PutMetadata(ctx context.Context, secretPath string, metadata KVMetadataPutInput) error {
+	pathToWriteTo := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
+
+	const (
+		casRequiredKey        = "cas_required"
+		deleteVersionAfterKey = "delete_version_after"
+		maxVersionsKey        = "max_versions"
+		customMetadataKey     = "custom_metadata"
+	)
+
+	// convert values to a map we can pass to Logical
+	metadataMap := make(map[string]interface{})
+	metadataMap[maxVersionsKey] = metadata.MaxVersions
+	metadataMap[deleteVersionAfterKey] = metadata.DeleteVersionAfter.String()
+	metadataMap[casRequiredKey] = metadata.CASRequired
+	metadataMap[customMetadataKey] = metadata.CustomMetadata
+
+	_, err := kv.c.Logical().WriteWithContext(ctx, pathToWriteTo, metadataMap)
+	if err != nil {
+		return fmt.Errorf("error writing secret metadata to %s: %w", pathToWriteTo, err)
+	}
+
+	return nil
+}
+
+// Patch additively updates the most recent version of a key-value secret,
+// differentiating it from Put which will fully overwrite the previous data.
+// Only the key-value pairs that are new or changing need to be provided.
+//
+// The WithMethod KVOption function can optionally be passed to dictate which
+// kind of patch to perform, as older Vault server versions (pre-1.9.0) may
+// only be able to use the old "rw" (read-then-write) style of partial update,
+// whereas newer Vault servers can use the default value of "patch" if the
+// client token's policy has the "patch" capability.
+func (kv *KVv2) Patch(ctx context.Context, secretPath string, newData map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
+	// determine patch method
+	var patchMethod string
+	var ok bool
+	for _, opt := range opts {
+		k, v := opt()
+		if k == "method" {
+			patchMethod, ok = v.(string)
+			if !ok {
+				return nil, fmt.Errorf("unsupported type provided for option value; value for patch method should be string \"rw\" or \"patch\"")
+			}
+		}
+	}
+
+	// Determine which kind of patch to use,
+	// the newer HTTP Patch style or the older read-then-write style
+	var kvs *KVSecret
+	var perr error
+	switch patchMethod {
+	case "rw":
+		kvs, perr = readThenWrite(ctx, kv.c, kv.mountPath, secretPath, newData)
+	case "patch":
+		kvs, perr = mergePatch(ctx, kv.c, kv.mountPath, secretPath, newData, opts...)
+	case "":
+		kvs, perr = mergePatch(ctx, kv.c, kv.mountPath, secretPath, newData, opts...)
+	default:
+		return nil, fmt.Errorf("unsupported patch method provided; value for patch method should be string \"rw\" or \"patch\"")
+	}
+	if perr != nil {
+		return nil, fmt.Errorf("unable to perform patch: %w", perr)
+	}
+	if kvs == nil {
+		return nil, fmt.Errorf("no secret was written to %s", secretPath)
+	}
+
+	return kvs, nil
+}
+
+// PatchMetadata can be used to replace just a subset of a secret's
+// metadata fields at a time, as opposed to PutMetadata which is used to
+// completely replace all fields on the previous metadata.
+func (kv *KVv2) PatchMetadata(ctx context.Context, secretPath string, metadata KVMetadataPatchInput) error {
+	pathToWriteTo := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
+
+	md, err := toMetadataMap(metadata)
+	if err != nil {
+		return fmt.Errorf("unable to create map for JSON merge patch request: %w", err)
+	}
+
+	_, err = kv.c.Logical().JSONMergePatch(ctx, pathToWriteTo, md)
+	if err != nil {
+		return fmt.Errorf("error patching metadata at %s: %w", pathToWriteTo, err)
+	}
+
+	return nil
+}
+
+// Delete deletes the most recent version of a secret from the KV v2
+// secrets engine. To delete an older version, use DeleteVersions.
+func (kv *KVv2) Delete(ctx context.Context, secretPath string) error {
+	pathToDelete := fmt.Sprintf("%s/data/%s", kv.mountPath, secretPath)
+
+	_, err := kv.c.Logical().DeleteWithContext(ctx, pathToDelete)
+	if err != nil {
+		return fmt.Errorf("error deleting secret at %s: %w", pathToDelete, err)
+	}
+
+	return nil
+}
+
+// DeleteVersions deletes the specified versions of a secret from the KV v2
+// secrets engine. To delete the latest version of a secret, just use Delete.
+func (kv *KVv2) DeleteVersions(ctx context.Context, secretPath string, versions []int) error {
+	// verb and path are different when trying to delete past versions
+	pathToDelete := fmt.Sprintf("%s/delete/%s", kv.mountPath, secretPath)
+
+	if len(versions) == 0 {
+		return nil
+	}
+
+	var versionsToDelete []string
+	for _, version := range versions {
+		versionsToDelete = append(versionsToDelete, strconv.Itoa(version))
+	}
+	versionsMap := map[string]interface{}{
+		"versions": versionsToDelete,
+	}
+	_, err := kv.c.Logical().WriteWithContext(ctx, pathToDelete, versionsMap)
+	if err != nil {
+		return fmt.Errorf("error deleting secret at %s: %w", pathToDelete, err)
+	}
+
+	return nil
+}
+
+// DeleteMetadata deletes all versions and metadata of the secret at the
+// given path.
+func (kv *KVv2) DeleteMetadata(ctx context.Context, secretPath string) error {
+	pathToDelete := fmt.Sprintf("%s/metadata/%s", kv.mountPath, secretPath)
+
+	_, err := kv.c.Logical().DeleteWithContext(ctx, pathToDelete)
+	if err != nil {
+		return fmt.Errorf("error deleting secret metadata at %s: %w", pathToDelete, err)
+	}
+
+	return nil
+}
+
+// Undelete undeletes the given versions of a secret, restoring the data
+// so that it can be fetched again with Get requests.
+//
+// A list of existing versions can be retrieved using the GetVersionsAsList method.
+func (kv *KVv2) Undelete(ctx context.Context, secretPath string, versions []int) error {
+	pathToUndelete := fmt.Sprintf("%s/undelete/%s", kv.mountPath, secretPath)
+
+	data := map[string]interface{}{
+		"versions": versions,
+	}
+
+	_, err := kv.c.Logical().WriteWithContext(ctx, pathToUndelete, data)
+	if err != nil {
+		return fmt.Errorf("error undeleting secret metadata at %s: %w", pathToUndelete, err)
+	}
+
+	return nil
+}
+
+// Destroy permanently removes the specified secret versions' data
+// from the Vault server. If no secret exists at the given path, no
+// action will be taken.
+//
+// A list of existing versions can be retrieved using the GetVersionsAsList method.
+func (kv *KVv2) Destroy(ctx context.Context, secretPath string, versions []int) error {
+	pathToDestroy := fmt.Sprintf("%s/destroy/%s", kv.mountPath, secretPath)
+
+	data := map[string]interface{}{
+		"versions": versions,
+	}
+
+	_, err := kv.c.Logical().WriteWithContext(ctx, pathToDestroy, data)
+	if err != nil {
+		return fmt.Errorf("error destroying secret metadata at %s: %w", pathToDestroy, err)
+	}
+
+	return nil
+}
+
+// Rollback can be used to roll a secret back to a previous
+// non-deleted/non-destroyed version. That previous version becomes the
+// next/newest version for the path.
+func (kv *KVv2) Rollback(ctx context.Context, secretPath string, toVersion int) (*KVSecret, error) {
+	// First, do a read to get the current version for check-and-set
+	latest, err := kv.Get(ctx, secretPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get latest version of secret: %w", err)
+	}
+
+	// Make sure a value already exists
+	if latest == nil {
+		return nil, fmt.Errorf("no secret was found: %w", err)
+	}
+
+	// Verify metadata found
+	if latest.VersionMetadata == nil {
+		return nil, fmt.Errorf("no metadata found; rollback can only be used on existing data")
+	}
+
+	// Now run it again and read the version we want to roll back to
+	rollbackVersion, err := kv.GetVersion(ctx, secretPath, toVersion)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get previous version %d of secret: %s", toVersion, err)
+	}
+
+	err = validateRollbackVersion(rollbackVersion)
+	if err != nil {
+		return nil, fmt.Errorf("invalid rollback version %d: %w", toVersion, err)
+	}
+
+	casVersion := latest.VersionMetadata.Version
+	kvs, err := kv.Put(ctx, secretPath, rollbackVersion.Data, WithCheckAndSet(casVersion))
+	if err != nil {
+		return nil, fmt.Errorf("unable to roll back to previous secret version: %w", err)
+	}
+
+	return kvs, nil
+}
+
+func extractCustomMetadata(secret *Secret) (map[string]interface{}, error) {
+	// Logical Writes return the metadata directly, Reads return it nested inside the "metadata" key
+	customMetadataInterface, ok := secret.Data["custom_metadata"]
+	if !ok {
+		metadataInterface, ok := secret.Data["metadata"]
+		if !ok { // if that's not found, bail since it should have had one or the other
+			return nil, fmt.Errorf("secret is missing expected fields")
+		}
+		metadataMap, ok := metadataInterface.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for 'metadata' element: %T (%#v)", metadataInterface, metadataInterface)
+		}
+		customMetadataInterface, ok = metadataMap["custom_metadata"]
+		if !ok {
+			return nil, fmt.Errorf("metadata missing expected field \"custom_metadata\": %v", metadataMap)
+		}
+	}
+
+	cm, ok := customMetadataInterface.(map[string]interface{})
+	if !ok && customMetadataInterface != nil {
+		return nil, fmt.Errorf("unexpected type for 'metadata' element: %T (%#v)", customMetadataInterface, customMetadataInterface)
+	}
+
+	return cm, nil
+}
+
+func extractDataAndVersionMetadata(secret *Secret) (*KVSecret, error) {
+	// A nil map is a valid value for data: secret.Data will be nil when this
+	// version of the secret has been deleted, but the metadata is still
+	// available.
+	var data map[string]interface{}
+	if secret.Data != nil {
+		dataInterface, ok := secret.Data["data"]
+		if !ok {
+			return nil, fmt.Errorf("missing expected 'data' element")
+		}
+
+		if dataInterface != nil {
+			data, ok = dataInterface.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("unexpected type for 'data' element: %T (%#v)", data, data)
+			}
+		}
+	}
+
+	metadata, err := extractVersionMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get version metadata: %w", err)
+	}
+
+	return &KVSecret{
+		Data:            data,
+		VersionMetadata: metadata,
+		Raw:             secret,
+	}, nil
+}
+
+func extractVersionMetadata(secret *Secret) (*KVVersionMetadata, error) {
+	var metadata *KVVersionMetadata
+
+	if secret.Data == nil {
+		return nil, nil
+	}
+
+	// Logical Writes return the metadata directly, Reads return it nested inside the "metadata" key
+	var metadataMap map[string]interface{}
+	metadataInterface, ok := secret.Data["metadata"]
+	if ok {
+		metadataMap, ok = metadataInterface.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for 'metadata' element: %T (%#v)", metadataInterface, metadataInterface)
+		}
+	} else {
+		metadataMap = secret.Data
+	}
+
+	// deletion_time usually comes in as an empty string which can't be
+	// processed as time.RFC3339, so we reset it to a convertible value
+	if metadataMap["deletion_time"] == "" {
+		metadataMap["deletion_time"] = time.Time{}
+	}
+
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+		Result:     &metadata,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error setting up decoder for API response: %w", err)
+	}
+
+	err = d.Decode(metadataMap)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding metadata from API response into VersionMetadata: %w", err)
+	}
+
+	return metadata, nil
+}
+
+func extractFullMetadata(secret *Secret) (*KVMetadata, error) {
+	var metadata *KVMetadata
+
+	if secret.Data == nil {
+		return nil, nil
+	}
+
+	if versions, ok := secret.Data["versions"]; ok {
+		versionsMap := versions.(map[string]interface{})
+		if len(versionsMap) > 0 {
+			for version, metadata := range versionsMap {
+				metadataMap := metadata.(map[string]interface{})
+				// deletion_time usually comes in as an empty string which can't be
+				// processed as time.RFC3339, so we reset it to a convertible value
+				if metadataMap["deletion_time"] == "" {
+					metadataMap["deletion_time"] = time.Time{}
+				}
+				versionInt, err := strconv.Atoi(version)
+				if err != nil {
+					return nil, fmt.Errorf("error converting version %s to integer: %w", version, err)
+				}
+				metadataMap["version"] = versionInt
+				versionsMap[version] = metadataMap // save the updated copy of the metadata map
+			}
+		}
+		secret.Data["versions"] = versionsMap // save the updated copy of the versions map
+	}
+
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeHookFunc(time.RFC3339),
+			mapstructure.StringToTimeDurationHookFunc(),
+		),
+		Result: &metadata,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error setting up decoder for API response: %w", err)
+	}
+
+	err = d.Decode(secret.Data)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding metadata from API response into KVMetadata: %w", err)
+	}
+
+	return metadata, nil
+}
+
+func validateRollbackVersion(rollbackVersion *KVSecret) error {
+	// Make sure a value already exists
+	if rollbackVersion == nil || rollbackVersion.Data == nil {
+		return fmt.Errorf("no secret found")
+	}
+
+	// Verify metadata found
+	if rollbackVersion.VersionMetadata == nil {
+		return fmt.Errorf("no version metadata found; rollback only works on existing data")
+	}
+
+	// Verify it hasn't been deleted
+	if !rollbackVersion.VersionMetadata.DeletionTime.IsZero() {
+		return fmt.Errorf("cannot roll back to a version that has been deleted")
+	}
+
+	if rollbackVersion.VersionMetadata.Destroyed {
+		return fmt.Errorf("cannot roll back to a version that has been destroyed")
+	}
+
+	// Verify old data found
+	if rollbackVersion.Data == nil {
+		return fmt.Errorf("no data found; rollback only works on existing data")
+	}
+
+	return nil
+}
+
+func mergePatch(ctx context.Context, client *Client, mountPath string, secretPath string, newData map[string]interface{}, opts ...KVOption) (*KVSecret, error) {
+	pathToMergePatch := fmt.Sprintf("%s/data/%s", mountPath, secretPath)
+
+	// take any other additional options provided
+	// and pass them along to the patch request
+	wrappedData := map[string]interface{}{
+		"data": newData,
+	}
+	options := make(map[string]interface{})
+	for _, opt := range opts {
+		k, v := opt()
+		options[k] = v
+	}
+	if len(opts) > 0 {
+		wrappedData["options"] = options
+	}
+
+	secret, err := client.Logical().JSONMergePatch(ctx, pathToMergePatch, wrappedData)
+	if err != nil {
+		// If it's a 405, that probably means the server is running a pre-1.9
+		// Vault version that doesn't support the HTTP PATCH method.
+		// Fall back to the old way of doing it.
+		if re, ok := err.(*ResponseError); ok && re.StatusCode == 405 {
+			return readThenWrite(ctx, client, mountPath, secretPath, newData)
+		}
+
+		if re, ok := err.(*ResponseError); ok && re.StatusCode == 403 {
+			return nil, fmt.Errorf("received 403 from Vault server; please ensure that token's policy has \"patch\" capability: %w", err)
+		}
+
+		return nil, fmt.Errorf("error performing merge patch to %s: %s", pathToMergePatch, err)
+	}
+
+	metadata, err := extractVersionMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("secret was written successfully, but unable to view version metadata from response: %w", err)
+	}
+
+	kvSecret := &KVSecret{
+		Data:            nil, // secret.Data in this case is the metadata
+		VersionMetadata: metadata,
+		Raw:             secret,
+	}
+
+	cm, err := extractCustomMetadata(secret)
+	if err != nil {
+		return nil, fmt.Errorf("error reading custom metadata for secret %s: %w", secretPath, err)
+	}
+	kvSecret.CustomMetadata = cm
+
+	return kvSecret, nil
+}
+
+func readThenWrite(ctx context.Context, client *Client, mountPath string, secretPath string, newData map[string]interface{}) (*KVSecret, error) {
+	// First, read the secret.
+	existingVersion, err := client.KVv2(mountPath).Get(ctx, secretPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading secret as part of read-then-write patch operation: %w", err)
+	}
+
+	// Make sure the secret already exists
+	if existingVersion == nil || existingVersion.Data == nil {
+		return nil, fmt.Errorf("no existing secret was found at %s when doing read-then-write patch operation: %w", secretPath, err)
+	}
+
+	// Verify existing secret has metadata
+	if existingVersion.VersionMetadata == nil {
+		return nil, fmt.Errorf("no metadata found at %s; patch can only be used on existing data", secretPath)
+	}
+
+	// Copy new data over with existing data
+	combinedData := existingVersion.Data
+	for k, v := range newData {
+		combinedData[k] = v
+	}
+
+	updatedSecret, err := client.KVv2(mountPath).Put(ctx, secretPath, combinedData, WithCheckAndSet(existingVersion.VersionMetadata.Version))
+	if err != nil {
+		return nil, fmt.Errorf("error writing secret to %s: %w", secretPath, err)
+	}
+
+	return updatedSecret, nil
+}
+
+func toMetadataMap(patchInput KVMetadataPatchInput) (map[string]interface{}, error) {
+	metadataMap := make(map[string]interface{})
+
+	const (
+		casRequiredKey        = "cas_required"
+		deleteVersionAfterKey = "delete_version_after"
+		maxVersionsKey        = "max_versions"
+		customMetadataKey     = "custom_metadata"
+	)
+
+	// The KVMetadataPatchInput struct is designed to have pointer fields so that
+	// the user can easily express the difference between explicitly setting a
+	// field back to its zero value (e.g. false), as opposed to just having
+	// the field remain unchanged (e.g. nil). This way, they only need to pass
+	// the fields they want to change.
+	if patchInput.MaxVersions != nil {
+		metadataMap[maxVersionsKey] = *(patchInput.MaxVersions)
+	}
+	if patchInput.CASRequired != nil {
+		metadataMap[casRequiredKey] = *(patchInput.CASRequired)
+	}
+	if patchInput.CustomMetadata != nil {
+		if len(patchInput.CustomMetadata) == 0 { // empty non-nil map means delete all the keys
+			metadataMap[customMetadataKey] = nil
+		} else {
+			metadataMap[customMetadataKey] = patchInput.CustomMetadata
+		}
+	}
+	if patchInput.DeleteVersionAfter != nil {
+		metadataMap[deleteVersionAfterKey] = patchInput.DeleteVersionAfter.String()
+	}
+
+	return metadataMap, nil
+}

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/lifetime_watcher.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/lifetime_watcher.go
@@ -113,7 +113,9 @@ type LifetimeWatcherInput struct {
 
 	// The new TTL, in seconds, that should be set on the lease. The TTL set
 	// here may or may not be honored by the vault server, based on Vault
-	// configuration or any associated max TTL values.
+	// configuration or any associated max TTL values. If specified, the
+	// minimum of this value and the remaining lease duration will be used
+	// for grace period calculations.
 	Increment int
 
 	// RenewBehavior controls what happens when a renewal errors or the
@@ -257,7 +259,7 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 
 	initialTime := time.Now()
 	priorDuration := time.Duration(initLeaseDuration) * time.Second
-	r.calculateGrace(priorDuration)
+	r.calculateGrace(priorDuration, time.Duration(r.increment)*time.Second)
 	var errorBackoff backoff.BackOff
 
 	for {
@@ -345,7 +347,7 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 			// extending. Once it stops extending, we've hit the max and need to
 			// rely on the grace duration.
 			if remainingLeaseDuration > priorDuration {
-				r.calculateGrace(remainingLeaseDuration)
+				r.calculateGrace(remainingLeaseDuration, time.Duration(r.increment)*time.Second)
 			}
 			priorDuration = remainingLeaseDuration
 
@@ -373,16 +375,21 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 	}
 }
 
-// calculateGrace calculates the grace period based on a reasonable set of
-// assumptions given the total lease time; it also adds some jitter to not have
-// clients be in sync.
-func (r *LifetimeWatcher) calculateGrace(leaseDuration time.Duration) {
-	if leaseDuration <= 0 {
+// calculateGrace calculates the grace period based on the minimum of the
+// remaining lease duration and the token increment value; it also adds some
+// jitter to not have clients be in sync.
+func (r *LifetimeWatcher) calculateGrace(leaseDuration, increment time.Duration) {
+	minDuration := leaseDuration
+	if minDuration > increment && increment > 0 {
+		minDuration = increment
+	}
+
+	if minDuration <= 0 {
 		r.grace = 0
 		return
 	}
 
-	leaseNanos := float64(leaseDuration.Nanoseconds())
+	leaseNanos := float64(minDuration.Nanoseconds())
 	jitterMax := 0.1 * leaseNanos
 
 	// For a given lease duration, we want to allow 80-90% of that to elapse,

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/logical.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/logical.go
@@ -323,7 +323,7 @@ func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (
 		c.c.SetToken(wrappingToken)
 	}
 
-	secret, err = c.Read(wrappedResponseLocation)
+	secret, err = c.ReadWithContext(ctx, wrappedResponseLocation)
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("error reading %q: {{err}}", wrappedResponseLocation), err)
 	}

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/output_policy.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/output_policy.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	ErrOutputPolicyRequest = "output a policy, please"
+)
+
+var LastOutputPolicyError *OutputPolicyError
+
+type OutputPolicyError struct {
+	method         string
+	path           string
+	finalHCLString string
+}
+
+func (d *OutputPolicyError) Error() string {
+	if d.finalHCLString == "" {
+		p, err := d.buildSamplePolicy()
+		if err != nil {
+			return err.Error()
+		}
+		d.finalHCLString = p
+	}
+
+	return ErrOutputPolicyRequest
+}
+
+func (d *OutputPolicyError) HCLString() (string, error) {
+	if d.finalHCLString == "" {
+		p, err := d.buildSamplePolicy()
+		if err != nil {
+			return "", err
+		}
+		d.finalHCLString = p
+	}
+	return d.finalHCLString, nil
+}
+
+// Builds a sample policy document from the request
+func (d *OutputPolicyError) buildSamplePolicy() (string, error) {
+	var capabilities []string
+	switch d.method {
+	case http.MethodGet, "":
+		capabilities = append(capabilities, "read")
+	case http.MethodPost, http.MethodPut:
+		capabilities = append(capabilities, "create")
+		capabilities = append(capabilities, "update")
+	case http.MethodPatch:
+		capabilities = append(capabilities, "patch")
+	case http.MethodDelete:
+		capabilities = append(capabilities, "delete")
+	case "LIST":
+		capabilities = append(capabilities, "list")
+	}
+
+	// sanitize, then trim the Vault address and v1 from the front of the path
+	path, err := url.PathUnescape(d.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to unescape request URL characters: %v", err)
+	}
+
+	// determine whether to add sudo capability
+	if IsSudoPath(path) {
+		capabilities = append(capabilities, "sudo")
+	}
+
+	// the OpenAPI response has a / in front of each path,
+	// but policies need the path without that leading slash
+	path = strings.TrimLeft(path, "/")
+
+	capStr := strings.Join(capabilities, `", "`)
+	return fmt.Sprintf(
+		`path "%s" {
+  capabilities = ["%s"]
+}`, path, capStr), nil
+}

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/plugin_helpers.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/plugin_helpers.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"net/url"
 	"os"
+	"regexp"
 
 	squarejwt "gopkg.in/square/go-jose.v2/jwt"
 
@@ -23,6 +24,49 @@ var (
 	// PluginUnwrapTokenEnv is the ENV name used to pass unwrap tokens to the
 	// plugin.
 	PluginUnwrapTokenEnv = "VAULT_UNWRAP_TOKEN"
+
+	// sudoPaths is a map containing the paths that require a token's policy
+	// to have the "sudo" capability. The keys are the paths as strings, in
+	// the same format as they are returned by the OpenAPI spec. The values
+	// are the regular expressions that can be used to test whether a given
+	// path matches that path or not (useful specifically for the paths that
+	// contain templated fields.)
+	sudoPaths = map[string]*regexp.Regexp{
+		"/auth/token/accessors/":                        regexp.MustCompile(`^/auth/token/accessors/$`),
+		"/pki/root":                                     regexp.MustCompile(`^/pki/root$`),
+		"/pki/root/sign-self-issued":                    regexp.MustCompile(`^/pki/root/sign-self-issued$`),
+		"/sys/audit":                                    regexp.MustCompile(`^/sys/audit$`),
+		"/sys/audit/{path}":                             regexp.MustCompile(`^/sys/audit/.+$`),
+		"/sys/auth/{path}":                              regexp.MustCompile(`^/sys/auth/.+$`),
+		"/sys/auth/{path}/tune":                         regexp.MustCompile(`^/sys/auth/.+/tune$`),
+		"/sys/config/auditing/request-headers":          regexp.MustCompile(`^/sys/config/auditing/request-headers$`),
+		"/sys/config/auditing/request-headers/{header}": regexp.MustCompile(`^/sys/config/auditing/request-headers/.+$`),
+		"/sys/config/cors":                              regexp.MustCompile(`^/sys/config/cors$`),
+		"/sys/config/ui/headers/":                       regexp.MustCompile(`^/sys/config/ui/headers/$`),
+		"/sys/config/ui/headers/{header}":               regexp.MustCompile(`^/sys/config/ui/headers/.+$`),
+		"/sys/leases":                                   regexp.MustCompile(`^/sys/leases$`),
+		"/sys/leases/lookup/":                           regexp.MustCompile(`^/sys/leases/lookup/$`),
+		"/sys/leases/lookup/{prefix}":                   regexp.MustCompile(`^/sys/leases/lookup/.+$`),
+		"/sys/leases/revoke-force/{prefix}":             regexp.MustCompile(`^/sys/leases/revoke-force/.+$`),
+		"/sys/leases/revoke-prefix/{prefix}":            regexp.MustCompile(`^/sys/leases/revoke-prefix/.+$`),
+		"/sys/plugins/catalog/{name}":                   regexp.MustCompile(`^/sys/plugins/catalog/[^/]+$`),
+		"/sys/plugins/catalog/{type}":                   regexp.MustCompile(`^/sys/plugins/catalog/[\w-]+$`),
+		"/sys/plugins/catalog/{type}/{name}":            regexp.MustCompile(`^/sys/plugins/catalog/[\w-]+/[^/]+$`),
+		"/sys/raw":                                      regexp.MustCompile(`^/sys/raw$`),
+		"/sys/raw/{path}":                               regexp.MustCompile(`^/sys/raw/.+$`),
+		"/sys/remount":                                  regexp.MustCompile(`^/sys/remount$`),
+		"/sys/revoke-force/{prefix}":                    regexp.MustCompile(`^/sys/revoke-force/.+$`),
+		"/sys/revoke-prefix/{prefix}":                   regexp.MustCompile(`^/sys/revoke-prefix/.+$`),
+		"/sys/rotate":                                   regexp.MustCompile(`^/sys/rotate$`),
+
+		// enterprise-only paths
+		"/sys/replication/dr/primary/secondary-token":          regexp.MustCompile(`^/sys/replication/dr/primary/secondary-token$`),
+		"/sys/replication/performance/primary/secondary-token": regexp.MustCompile(`^/sys/replication/performance/primary/secondary-token$`),
+		"/sys/replication/primary/secondary-token":             regexp.MustCompile(`^/sys/replication/primary/secondary-token$`),
+		"/sys/replication/reindex":                             regexp.MustCompile(`^/sys/replication/reindex$`),
+		"/sys/storage/raft/snapshot-auto/config/":              regexp.MustCompile(`^/sys/storage/raft/snapshot-auto/config/$`),
+		"/sys/storage/raft/snapshot-auto/config/{name}":        regexp.MustCompile(`^/sys/storage/raft/snapshot-auto/config/[^/]+$`),
+	}
 )
 
 // PluginAPIClientMeta is a helper that plugins can use to configure TLS connections
@@ -191,4 +235,29 @@ func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig)
 
 		return tlsConfig, nil
 	}
+}
+
+func SudoPaths() map[string]*regexp.Regexp {
+	return sudoPaths
+}
+
+// Determine whether the given path requires the sudo capability
+func IsSudoPath(path string) bool {
+	// Return early if the path is any of the non-templated sudo paths.
+	if _, ok := sudoPaths[path]; ok {
+		return true
+	}
+
+	// Some sudo paths have templated fields in them.
+	// (e.g. /sys/revoke-prefix/{prefix})
+	// The values in the sudoPaths map are actually regular expressions,
+	// so we can check if our path matches against them.
+	for _, sudoPathRegexp := range sudoPaths {
+		match := sudoPathRegexp.MatchString(path)
+		if match {
+			return true
+		}
+	}
+
+	return false
 }

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/secret.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/secret.go
@@ -94,12 +94,7 @@ func (s *Secret) TokenRemainingUses() (int, error) {
 		return -1, nil
 	}
 
-	uses, err := parseutil.ParseInt(s.Data["num_uses"])
-	if err != nil {
-		return 0, err
-	}
-
-	return int(uses), nil
+	return parseutil.SafeParseInt(s.Data["num_uses"])
 }
 
 // TokenPolicies returns the standardized list of policies for the given secret.

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_hastatus.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_hastatus.go
@@ -37,4 +37,7 @@ type HANode struct {
 	ClusterAddress string     `json:"cluster_address"`
 	ActiveNode     bool       `json:"active_node"`
 	LastEcho       *time.Time `json:"last_echo"`
+	Version        string     `json:"version"`
+	UpgradeVersion string     `json:"upgrade_version,omitempty"`
+	RedundancyZone string     `json:"redundancy_zone,omitempty"`
 }

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_mfa.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_mfa.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+func (c *Sys) MFAValidate(requestID string, payload map[string]interface{}) (*Secret, error) {
+	return c.MFAValidateWithContext(context.Background(), requestID, payload)
+}
+
+func (c *Sys) MFAValidateWithContext(ctx context.Context, requestID string, payload map[string]interface{}) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	body := map[string]interface{}{
+		"mfa_request_id": requestID,
+		"mfa_payload":    payload,
+	}
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/mfa/validate"))
+	if err := r.SetJSONBody(body); err != nil {
+		return nil, fmt.Errorf("failed to set request body: %w", err)
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse secret from response: %w", err)
+	}
+
+	if secret == nil {
+		return nil, fmt.Errorf("data from server response is empty")
+	}
+
+	return secret, nil
+}

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_monitor.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_monitor.go
@@ -5,17 +5,25 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
+	"github.com/hashicorp/vault/sdk/helper/logging"
 )
 
 // Monitor returns a channel that outputs strings containing the log messages
 // coming from the server.
-func (c *Sys) Monitor(ctx context.Context, logLevel string) (chan string, error) {
+func (c *Sys) Monitor(ctx context.Context, logLevel string, logFormat string) (chan string, error) {
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/monitor")
 
 	if logLevel == "" {
 		r.Params.Add("log_level", "info")
 	} else {
 		r.Params.Add("log_level", logLevel)
+	}
+
+	if logFormat == "" || logFormat == logging.UnspecifiedFormat.String() {
+		r.Params.Add("log_format", "standard")
+	} else {
+		r.Params.Add("log_format", logFormat)
 	}
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_plugins.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_plugins.go
@@ -100,23 +100,24 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 		PluginsByType: make(map[consts.PluginType][]string),
 	}
 	if i.Type == consts.PluginTypeUnknown {
-		for pluginTypeStr, pluginsRaw := range secret.Data {
-			pluginType, err := consts.ParsePluginType(pluginTypeStr)
-			if err != nil {
-				return nil, err
+		for _, pluginType := range consts.PluginTypes {
+			pluginsRaw, ok := secret.Data[pluginType.String()]
+			if !ok {
+				continue
 			}
 
 			pluginsIfc, ok := pluginsRaw.([]interface{})
 			if !ok {
-				return nil, fmt.Errorf("unable to parse plugins for %q type", pluginTypeStr)
+				return nil, fmt.Errorf("unable to parse plugins for %q type", pluginType.String())
 			}
 
-			plugins := make([]string, len(pluginsIfc))
-			for i, nameIfc := range pluginsIfc {
+			plugins := make([]string, 0, len(pluginsIfc))
+			for _, nameIfc := range pluginsIfc {
 				name, ok := nameIfc.(string)
 				if !ok {
+					continue
 				}
-				plugins[i] = name
+				plugins = append(plugins, name)
 			}
 			result.PluginsByType[pluginType] = plugins
 		}

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_seal.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/api/sys_seal.go
@@ -101,6 +101,7 @@ type SealStatusResponse struct {
 	Progress     int    `json:"progress"`
 	Nonce        string `json:"nonce"`
 	Version      string `json:"version"`
+	BuildDate    string `json:"build_date"`
 	Migration    bool   `json:"migration"`
 	ClusterName  string `json:"cluster_name,omitempty"`
 	ClusterID    string `json:"cluster_id,omitempty"`

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/sdk/helper/certutil/helpers.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/sdk/helper/certutil/helpers.go
@@ -446,18 +446,30 @@ func ParsePublicKeyPEM(data []byte) (interface{}, error) {
 	return nil, errors.New("data does not contain any valid public keys")
 }
 
-// addPolicyIdentifiers adds certificate policies extension
-//
+// AddPolicyIdentifiers adds certificate policies extension, based on CreationBundle
 func AddPolicyIdentifiers(data *CreationBundle, certTemplate *x509.Certificate) {
-	for _, oidstr := range data.Params.PolicyIdentifiers {
-		oid, err := StringToOid(oidstr)
+	oidOnly := true
+	for _, oidStr := range data.Params.PolicyIdentifiers {
+		oid, err := StringToOid(oidStr)
 		if err == nil {
 			certTemplate.PolicyIdentifiers = append(certTemplate.PolicyIdentifiers, oid)
+		}
+		if err != nil {
+			oidOnly = false
+		}
+	}
+	if !oidOnly { // Because all policy information is held in the same extension, when we use an extra extension to
+		// add policy qualifier information, that overwrites any information in the PolicyIdentifiers field on the Cert
+		// Template, so we need to reparse all the policy identifiers here
+		extension, err := CreatePolicyInformationExtensionFromStorageStrings(data.Params.PolicyIdentifiers)
+		if err == nil {
+			// If this errors out, don't add it, rely on the OIDs parsed into PolicyIdentifiers above
+			certTemplate.ExtraExtensions = append(certTemplate.ExtraExtensions, *extension)
 		}
 	}
 }
 
-// addExtKeyUsageOids adds custom extended key usage OIDs to certificate
+// AddExtKeyUsageOids adds custom extended key usage OIDs to certificate
 func AddExtKeyUsageOids(data *CreationBundle, certTemplate *x509.Certificate) {
 	for _, oidstr := range data.Params.ExtKeyUsageOIDs {
 		oid, err := StringToOid(oidstr)

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/sdk/helper/certutil/types.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/sdk/helper/certutil/types.go
@@ -17,7 +17,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -893,4 +896,115 @@ func (p *KeyBundle) ToPrivateKeyPemString() (string, error) {
 	}
 
 	return "", errutil.InternalError{Err: "No Private Key Bytes to Wrap"}
+}
+
+// PolicyIdentifierWithQualifierEntry Structure for Internal Storage
+type PolicyIdentifierWithQualifierEntry struct {
+	PolicyIdentifierOid string `json:"oid",mapstructure:"oid"`
+	CPS                 string `json:"cps,omitempty",mapstructure:"cps"`
+	Notice              string `json:"notice,omitempty",mapstructure:"notice"`
+}
+
+// GetPolicyIdentifierFromString parses out the internal structure of a Policy Identifier
+func GetPolicyIdentifierFromString(policyIdentifier string) (*PolicyIdentifierWithQualifierEntry, error) {
+	if policyIdentifier == "" {
+		return nil, nil
+	}
+	entry := &PolicyIdentifierWithQualifierEntry{}
+	// Either a OID, or a JSON Entry: First check OID:
+	_, err := StringToOid(policyIdentifier)
+	if err == nil {
+		entry.PolicyIdentifierOid = policyIdentifier
+		return entry, nil
+	}
+	// Now Check If JSON Entry
+	jsonErr := json.Unmarshal([]byte(policyIdentifier), &entry)
+	if jsonErr != nil { // Neither, if we got here
+		return entry, errors.New(fmt.Sprintf("Policy Identifier %q is neither a valid OID: %s, Nor JSON Policy Identifier: %s", policyIdentifier, err.Error(), jsonErr.Error()))
+	}
+	return entry, nil
+}
+
+// Policy Identifier with Qualifier Structure for ASN Marshalling:
+
+var policyInformationOid = asn1.ObjectIdentifier{2, 5, 29, 32}
+
+type policyInformation struct {
+	PolicyIdentifier asn1.ObjectIdentifier
+	Qualifiers       []interface{} `asn1:"tag:optional,omitempty"`
+}
+
+var cpsPolicyQualifierID = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 1}
+
+type cpsUrlPolicyQualifier struct {
+	PolicyQualifierID asn1.ObjectIdentifier
+	Qualifier         string `asn1:"tag:optional,ia5"`
+}
+
+var userNoticePolicyQualifierID = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 2}
+
+type userNoticePolicyQualifier struct {
+	PolicyQualifierID asn1.ObjectIdentifier
+	Qualifier         userNotice
+}
+
+type userNotice struct {
+	ExplicitText string `asn1:"tag:optional,utf8"`
+}
+
+func createPolicyIdentifierWithQualifier(entry PolicyIdentifierWithQualifierEntry) (*policyInformation, error) {
+	// Each Policy is Identified by a Unique ID, as designated here:
+	policyOid, err := StringToOid(entry.PolicyIdentifierOid)
+	if err != nil {
+		return nil, err
+	}
+	pi := policyInformation{
+		PolicyIdentifier: policyOid,
+	}
+	if entry.CPS != "" {
+		qualifier := cpsUrlPolicyQualifier{
+			PolicyQualifierID: cpsPolicyQualifierID,
+			Qualifier:         entry.CPS,
+		}
+		pi.Qualifiers = append(pi.Qualifiers, qualifier)
+	}
+	if entry.Notice != "" {
+		qualifier := userNoticePolicyQualifier{
+			PolicyQualifierID: userNoticePolicyQualifierID,
+			Qualifier: userNotice{
+				ExplicitText: entry.Notice,
+			},
+		}
+		pi.Qualifiers = append(pi.Qualifiers, qualifier)
+	}
+	return &pi, nil
+}
+
+// CreatePolicyInformationExtensionFromStorageStrings parses the stored policyIdentifiers, which might be JSON Policy
+// Identifier with Qualifier Entries or String OIDs, and returns an extension if everything parsed correctly, and an
+// error if constructing
+func CreatePolicyInformationExtensionFromStorageStrings(policyIdentifiers []string) (*pkix.Extension, error) {
+	var policyInformationList []policyInformation
+	for _, policyIdentifierStr := range policyIdentifiers {
+		policyIdentifierEntry, err := GetPolicyIdentifierFromString(policyIdentifierStr)
+		if err != nil {
+			return nil, err
+		}
+		if policyIdentifierEntry != nil { // Okay to skip empty entries if there is no error
+			policyInformationStruct, err := createPolicyIdentifierWithQualifier(*policyIdentifierEntry)
+			if err != nil {
+				return nil, err
+			}
+			policyInformationList = append(policyInformationList, *policyInformationStruct)
+		}
+	}
+	asn1Bytes, err := asn1.Marshal(policyInformationList)
+	if err != nil {
+		return nil, err
+	}
+	return &pkix.Extension{
+		Id:       policyInformationOid,
+		Critical: false,
+		Value:    asn1Bytes,
+	}, nil
 }

--- a/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/sdk/version/version_base.go
+++ b/third_party/VENDOR-LICENSE/github.com/hashicorp/vault/sdk/version/version_base.go
@@ -11,7 +11,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.11.0"
+	Version           = "1.12.0"
 	VersionPrerelease = "dev1"
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

This change bumps some vulnerable deps reported in https://github.com/sigstore/policy-controller/issues/26

```
go get -u github.com/hashicorp/vault/api@latest
go get -u github.com/hashicorp/vault/sdk@latest
go get -u google.golang.org/protobuf@latest (no change)
```

It also removes the `defaultBaseImage` in .ko.yaml, which made the controller images based on `gcr.io/distroless/base:debug-nonroot`, I think unnecessarily. I think this was selected as the base image for `cosign` and just picked up as the default when the K8s components were added to the repo.

In any case, I think it's safe to remove them now.

After this change, there are still some detected vulnerabilities:

```
$ grype $(ko build ./cmd/policy_webhook/)
NAME                            INSTALLED  FIXED-IN  TYPE       VULNERABILITY   SEVERITY
github.com/hashicorp/vault/api  v1.7.1               go-module  CVE-2021-32923  High
github.com/hashicorp/vault/api  v1.7.1               go-module  CVE-2022-25244  Medium
github.com/hashicorp/vault/api  v1.7.1               go-module  CVE-2021-38553  Medium
github.com/hashicorp/vault/api  v1.7.1               go-module  CVE-2021-38554  Medium
github.com/hashicorp/vault/api  v1.7.1               go-module  CVE-2021-43998  Medium
github.com/hashicorp/vault/api  v1.7.1               go-module  CVE-2021-45042  Medium
github.com/hashicorp/vault/api  v1.7.1               go-module  CVE-2021-41802  Medium
github.com/hashicorp/vault/sdk  v0.5.1               go-module  CVE-2021-38554  Medium
github.com/hashicorp/vault/sdk  v0.5.1               go-module  CVE-2018-19786  High
github.com/hashicorp/vault/sdk  v0.5.1               go-module  CVE-2020-13223  High
github.com/hashicorp/vault/sdk  v0.5.1               go-module  CVE-2020-25594  Medium
github.com/hashicorp/vault/sdk  v0.5.1               go-module  CVE-2021-3024   Medium
github.com/hashicorp/vault/sdk  v0.5.1               go-module  CVE-2021-27400  High
github.com/hashicorp/vault/sdk  v0.5.1               go-module  CVE-2021-41802  Medium
google.golang.org/protobuf      v1.28.0              go-module  CVE-2015-5237   High
google.golang.org/protobuf      v1.28.0              go-module  CVE-2021-22570  High
```

```
$ grype $(ko build ./cmd/webhook/)
NAME                              INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/open-policy-agent/opa  v0.35.0    0.37.2    go-module  GHSA-hcw3-j74m-qc58  Medium
github.com/open-policy-agent/opa  v0.35.0    0.40.0    go-module  GHSA-x7f3-62pm-9p38  High
google.golang.org/protobuf        v1.28.0              go-module  CVE-2015-5237        High
google.golang.org/protobuf        v1.28.0              go-module  CVE-2021-22570       High
```

(The OPA dep is stuck for now due to other deps, we'll track that separately)

---

```release-note
Controller and webhook images are based on gcr.io/distroless/static:nonroot and no longer contain a shell.
```
