### PR TITLE
Fix #28. Treat multiple authorities as OR instead of AND.

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -262,7 +262,7 @@ func validatePolicies(ctx context.Context, namespace string, ref name.Reference,
 			result := retChannelType{name: cipName}
 
 			result.policyResult, result.errors = ValidatePolicy(ctx, namespace, ref, cip, remoteOpts...)
-			if len(result.errors) == 0 {
+			if len(result.policyResult.AuthorityMatches) > 0 {
 				// Ok, at least one Authority  on the policy passed. If there's a CIP level
 				// policy, apply it against the results of the successful Authorities
 				// outputs.
@@ -366,7 +366,8 @@ func ValidatePolicy(ctx context.Context, namespace string, ref name.Reference, c
 		}()
 	}
 	// If none of the Authorities for a given policy pass the checks, gather
-	// the errors here. If one passes, do not return the errors.
+	// the errors here. Even if there are errors, return the matched
+	// authoritypolicies.
 	authorityErrors := []error{}
 	// We collect all the successfully satisfied Authorities into this and
 	// return it.
@@ -392,9 +393,9 @@ func ValidatePolicy(ctx context.Context, namespace string, ref name.Reference, c
 			}
 		}
 	}
-	if len(authorityErrors) > 0 {
-		return nil, authorityErrors
-	}
+	// Even if there are errors, return the policies, since as per the
+	// spec, we just need one signature to pass checks. If more than
+	// one are required, that is enforced at the policy level.
 	return policyResult, authorityErrors
 }
 

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -262,21 +262,23 @@ func validatePolicies(ctx context.Context, namespace string, ref name.Reference,
 			result := retChannelType{name: cipName}
 
 			result.policyResult, result.errors = ValidatePolicy(ctx, namespace, ref, cip, remoteOpts...)
-			if len(result.policyResult.AuthorityMatches) > 0 {
-				// Ok, at least one Authority  on the policy passed. If there's a CIP level
-				// policy, apply it against the results of the successful Authorities
-				// outputs.
-				if cip.Policy != nil {
-					logging.FromContext(ctx).Infof("Validating CIP level policy for %s", cipName)
-					policyJSON, err := json.Marshal(result.policyResult)
+			// If there are authorities that validated in the CIP and there's
+			// a CIP level policy, apply it against the results of the
+			// successful Authorities outputs.
+			if result.policyResult != nil && cip.Policy != nil {
+				logging.FromContext(ctx).Infof("Validating CIP level policy for %s", cipName)
+				policyJSON, err := json.Marshal(result.policyResult)
+				if err != nil {
+					// nil out any policyResults since CIP level policy failed
+					result.policyResult = nil
+					result.errors = append(result.errors, err)
+				} else {
+					err = policy.EvaluatePolicyAgainstJSON(ctx, "ClusterImagePolicy", cip.Policy.Type, cip.Policy.Data, policyJSON)
 					if err != nil {
+						logging.FromContext(ctx).Warnf("Failed to validate CIP level policy against %s", string(policyJSON))
+						// nil out any policyResults since CIP level policy failed
+						result.policyResult = nil
 						result.errors = append(result.errors, err)
-					} else {
-						logging.FromContext(ctx).Debugf("Validating CIP level policy against %s", string(policyJSON))
-						err = policy.EvaluatePolicyAgainstJSON(ctx, "ClusterImagePolicy", cip.Policy.Type, cip.Policy.Data, policyJSON)
-						if err != nil {
-							result.errors = append(result.errors, err)
-						}
 					}
 				}
 			}
@@ -299,10 +301,15 @@ func validatePolicies(ctx context.Context, namespace string, ref name.Reference,
 				continue
 			}
 			switch {
+			// Return AuthorityMatches before errors, since even if there
+			// are errors, if there are 0 or more authorities that match,
+			// it will pass the Policy. Of course, a CIP level policy can
+			// override this behaviour, but that has been checked above and
+			// if it failed, it will nil out the policyResult.
+			case result.policyResult != nil:
+				policyResults[result.name] = result.policyResult
 			case len(result.errors) > 0:
 				ret[result.name] = append(ret[result.name], result.errors...)
-			case len(result.policyResult.AuthorityMatches) > 0:
-				policyResults[result.name] = result.policyResult
 			default:
 				ret[result.name] = append(ret[result.name], fmt.Errorf("failed to process policy: %s", result.name))
 			}
@@ -313,9 +320,10 @@ func validatePolicies(ctx context.Context, namespace string, ref name.Reference,
 }
 
 // ValidatePolicy will go through all the Authorities for a given image/policy
-// and return a success if at least one of the Authorities validated the
-// signatures OR attestations if atttestations were specified.
-// Returns PolicyResult, or errors encountered if none of the authorities
+// and return validated authorities if at least one of the Authorities
+// validated the signatures OR attestations if atttestations were specified.
+// Returns PolicyResult if one or more authorities matched, otherwise nil.
+// In any case returns all errors encountered if none of the authorities
 // passed.
 func ValidatePolicy(ctx context.Context, namespace string, ref name.Reference, cip webhookcip.ClusterImagePolicy, remoteOpts ...ociremote.Option) (*PolicyResult, []error) {
 	// Each gofunc creates and puts one of these into a results channel.
@@ -394,8 +402,13 @@ func ValidatePolicy(ctx context.Context, namespace string, ref name.Reference, c
 		}
 	}
 	// Even if there are errors, return the policies, since as per the
-	// spec, we just need one signature to pass checks. If more than
-	// one are required, that is enforced at the policy level.
+	// spec, we just need one authority to pass checks. If more than
+	// one are required, that is enforced at the CIP policy level.
+	// If however there are no authorityMatches, return nil so we don't have
+	// to keep checking the length on the returned calls.
+	if len(policyResult.AuthorityMatches) == 0 {
+		return nil, authorityErrors
+	}
 	return policyResult, authorityErrors
 }
 

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -1402,6 +1402,7 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 				},
 			}},
 		},
+		want:     &PolicyResult{AuthorityMatches: make(map[string]AuthorityMatch)},
 		wantErrs: []string{"failed to validate public keys with authority authority-0 for gcr.io/distroless/static@sha256:be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4: bad signature"},
 		cvs:      fail,
 	}, {
@@ -1423,6 +1424,31 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 				}},
 		},
 		cvs: pass,
+	}, {
+		name: "simple, public key and keyless, one works, one doesn't",
+		policy: webhookcip.ClusterImagePolicy{
+			Authorities: []webhookcip.Authority{{
+				Name: "authority-0",
+				Key: &webhookcip.KeyRef{
+					PublicKeys: []crypto.PublicKey{authorityKeyCosignPub},
+				},
+			}, {
+				Name: "authority-1",
+				Keyless: &webhookcip.KeylessRef{
+					URL: badURL,
+				},
+			}},
+		},
+		want: &PolicyResult{
+			AuthorityMatches: map[string]AuthorityMatch{
+				"authority-0": {
+					Signatures: []PolicySignature{{
+						Subject: "PLACEHOLDER",
+						Issuer:  "PLACEHOLDER"}},
+				}},
+		},
+		wantErrs: []string{`fetching FulcioRoot: getting root cert: parse "http://http:%2F%2Fexample.com%2F/api/v1/rootCert": invalid port ":%2F%2Fexample.com%2F" after host`},
+		cvs:      authorityPublicKeyCVS,
 	}, {
 		name: "simple, public key, no error",
 		policy: webhookcip.ClusterImagePolicy{

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -369,7 +369,7 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 			&config.Config{
 				ImagePolicyConfig: &config.ImagePolicyConfig{
 					Policies: map[string]webhookcip.ClusterImagePolicy{
-						"cluster-image-policy-keyless": {
+						"cluster-image-policy-keyless-bad-cip": {
 							Images: []v1alpha1.ImagePattern{{
 								Glob: "gcr.io/*/*",
 							}},
@@ -383,7 +383,7 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 							Policy: &webhookcip.AttestationPolicy{
 								Name: "invalid json policy",
 								Type: "cue",
-								Data: `{"wontgo}`,
+								Data: `{"wontgo`,
 							},
 						},
 					},
@@ -392,10 +392,10 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 		),
 		want: func() *apis.FieldError {
 			var errs *apis.FieldError
-			fe := apis.ErrGeneric("failed policy: cluster-image-policy-keyless", "image").ViaFieldIndex("initContainers", 0)
+			fe := apis.ErrGeneric("failed policy: cluster-image-policy-keyless-bad-cip", "image").ViaFieldIndex("initContainers", 0)
 			fe.Details = fmt.Sprintf("%s failed evaluating cue policy for ClusterImagePolicy : failed to compile the cue policy with error: string literal not terminated", digest.String())
 			errs = errs.Also(fe)
-			fe2 := apis.ErrGeneric("failed policy: cluster-image-policy-keyless", "image").ViaFieldIndex("containers", 0)
+			fe2 := apis.ErrGeneric("failed policy: cluster-image-policy-keyless-bad-cip", "image").ViaFieldIndex("containers", 0)
 			fe2.Details = fmt.Sprintf("%s failed evaluating cue policy for ClusterImagePolicy : failed to compile the cue policy with error: string literal not terminated", digest.String())
 			errs = errs.Also(fe2)
 			return errs
@@ -1402,7 +1402,6 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 				},
 			}},
 		},
-		want:     &PolicyResult{AuthorityMatches: make(map[string]AuthorityMatch)},
 		wantErrs: []string{"failed to validate public keys with authority authority-0 for gcr.io/distroless/static@sha256:be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4: bad signature"},
 		cvs:      fail,
 	}, {

--- a/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
@@ -1,0 +1,37 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is exactly like image-policy-key but we add a keyless
+# entry. Regress test for
+# https://github.com/sigstore/policy-controller/issues/28
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-key
+spec:
+  images:
+  - glob: registry.local:5000/policy-controller/demo*
+  authorities:
+  - key:
+      data: |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZxAfzrQG1EbWyCI8LiSB7YgSFXoI
+        FNGTyQGKHFc6/H8TQumT9VLS78pUwtv3w7EfKoyFZoP32KrO7nzUy2q6Cw==
+        -----END PUBLIC KEY-----
+    ctlog:
+      url: http://rekor.rekor-system.svc
+  - keyless:
+      url: http://fulcio.fulcio-system.svc
+    ctlog:
+      url: http://rekor.rekor-system.svc

--- a/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
@@ -32,6 +32,6 @@ spec:
     ctlog:
       url: http://rekor.rekor-system.svc
   - keyless:
-      url: http://fulcio.fulcio-system.svc
+      url: http://fulcio.sigstore.dev
     ctlog:
-      url: http://rekor.rekor-system.svc
+      url: http://rekor.sigstore.dev

--- a/test/testdata/policy-controller/e2e/cip-key-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-with-attestations.yaml
@@ -37,12 +37,3 @@ spec:
         data: |
           predicateType: "cosign.sigstore.dev/attestation/v1"
           predicate: Data: "foobar key e2e test"
-  - name: verify signature
-    key:
-      data: |
-        -----BEGIN PUBLIC KEY-----
-        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZxAfzrQG1EbWyCI8LiSB7YgSFXoI
-        FNGTyQGKHFc6/H8TQumT9VLS78pUwtv3w7EfKoyFZoP32KrO7nzUy2q6Cw==
-        -----END PUBLIC KEY-----
-    ctlog:
-      url: http://rekor.rekor-system.svc

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
@@ -42,7 +42,6 @@ spec:
     type: cue
     data: |
       package sigstore
-      import "struct"
       import "list"
       authorityMatches: {
         verifysignature: {

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
@@ -20,7 +20,7 @@ spec:
   images:
   - glob: registry.local:5000/policy-controller/demo*
   authorities:
-  - name: verifycustomattestation
+  - name: attestation
     keyless:
       url: http://fulcio.fulcio-system.svc
     ctlog:
@@ -33,23 +33,3 @@ spec:
         data: |
           predicateType: "cosign.sigstore.dev/attestation/v1"
           predicate: Data: "foobar e2e test"
-  - name: verifysignature
-    keyless:
-      url: http://fulcio.fulcio-system.svc
-    ctlog:
-      url: http://rekor.rekor-system.svc
-  policy:
-    type: cue
-    data: |
-      package sigstore
-      import "list"
-      authorityMatches: {
-        verifysignature: {
-          signatures: list.MaxItems(1) & list.MinItems(1)
-        },
-        if (len(authorityMatches.verifycustomattestation.attestations) < 1) {
-          keylessattMinAttestations: 1
-          keylessattMinAttestations: "Error"
-        },
-      }
-

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
@@ -20,7 +20,7 @@ spec:
   images:
   - glob: registry.local:5000/policy-controller/demo*
   authorities:
-  - name: verify custom attestation
+  - name: verifycustomattestation
     keyless:
       url: http://fulcio.fulcio-system.svc
     ctlog:
@@ -33,8 +33,24 @@ spec:
         data: |
           predicateType: "cosign.sigstore.dev/attestation/v1"
           predicate: Data: "foobar e2e test"
-  - name: verify signature
+  - name: verifysignature
     keyless:
       url: http://fulcio.fulcio-system.svc
     ctlog:
       url: http://rekor.rekor-system.svc
+  policy:
+    type: cue
+    data: |
+      package sigstore
+      import "struct"
+      import "list"
+      authorityMatches: {
+        verifysignature: {
+          signatures: list.MaxItems(1) & list.MinItems(1)
+        },
+        if (len(authorityMatches.verifycustomattestation.attestations) < 1) {
+          keylessattMinAttestations: 1
+          keylessattMinAttestations: "Error"
+        },
+      }
+


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix #28 by treating multiple authorities as OR instead of AND. This was what it was supposed to be as per the spec all along.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* Fix bug #28 where multiple authorities were treated as AND instead of OR as specified.
```
