### PR TITLE
Allow for @ symbol on globs to support image refs with digest

### DIFF
--- a/pkg/apis/glob/glob.go
+++ b/pkg/apis/glob/glob.go
@@ -30,7 +30,7 @@ const (
 	DockerhubPublicRepository = "library/"
 )
 
-var validGlob = regexp.MustCompile(`^[a-zA-Z0-9-_:\/\*\.]+$`)
+var validGlob = regexp.MustCompile(`^[a-zA-Z0-9-_:\/\*\.@]+$`)
 
 // Compile attempts to normalize the glob and turn it into a regular expression
 // that we can use for matching image names.

--- a/pkg/apis/glob/glob_test.go
+++ b/pkg/apis/glob/glob_test.go
@@ -72,6 +72,13 @@ func TestGlobMatch(t *testing.T) {
 		// Upgrading unqualified globs to assume index.docker.io prefix.
 		{image: "foo", glob: "*", wantMatch: true},
 		{image: "myuser/myapp", glob: "*/*", wantMatch: true},
+
+		// Image with digest (exact match)
+		{
+			image:     "ghcr.io/foo@sha256:5504f2a95018e3d8a52d80d9e1a128c6ea337581808ff9fe96f5628ce2336350",
+			glob:      "ghcr.io/foo@sha256:5504f2a95018e3d8a52d80d9e1a128c6ea337581808ff9fe96f5628ce2336350",
+			wantMatch: true,
+		},
 	} {
 		t.Run(c.image+"|"+c.glob, func(t *testing.T) {
 			match, err := Match(c.glob, c.image)

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -115,6 +115,26 @@ func TestImagePatternValidation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "Glob should pass with exact digest image",
+			expectErr: false,
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "ghcr.io/foo@sha256:5504f2a95018e3d8a52d80d9e1a128c6ea337581808ff9fe96f5628ce2336350",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Key: &KeyRef{
+								KMS: "kms://key/path",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -222,6 +222,26 @@ func TestKeyValidation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "Glob should pass with exact digest image",
+			expectErr: false,
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "ghcr.io/foo@sha256:5504f2a95018e3d8a52d80d9e1a128c6ea337581808ff9fe96f5628ce2336350",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Key: &KeyRef{
+								KMS: "kms://key/path",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
In #60, support for exact strings of image refs with a digest stopped working.

Example:
```
ghcr.io/foo@sha256:5504f2a95018e3d8a52d80d9e1a128c6ea337581808ff9fe96f5628ce2336350
```

This just adds the `@` character in the regex pattern for glob string validation.