### PR TITLE
Add policy-tester CLI for testing ClusterImagePolicies

### DIFF
--- a/.github/workflows/policy-tester.yml
+++ b/.github/workflows/policy-tester.yml
@@ -1,0 +1,54 @@
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: policy-tester
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main', 'release-*']
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  verify:
+    name: Verify policy-tester
+    runs-on: ubuntu-latest
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+    - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
+      with:
+        go-version: '1.17'
+        check-latest: true
+
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      with:
+        path: ./src/github.com/${{ github.repository }}
+        fetch-depth: 0
+
+    - working-directory: ./src/github.com/${{ github.repository }}
+      run: |
+        # Build the policy-tester CLI
+        make policy-tester
+
+        # Make sure it runs and verifies a policy against valid image
+        (set -o pipefail && \
+          ./policy-tester \
+              test/testdata/policy-controller/tester/cip-public-keyless.yaml \
+              ghcr.io/sigstore/cosign/cosign:v1.9.0 | jq)

--- a/.github/workflows/policy-tester.yml
+++ b/.github/workflows/policy-tester.yml
@@ -50,5 +50,5 @@ jobs:
         # Make sure it runs and verifies a policy against valid image
         (set -o pipefail && \
           ./policy-tester \
-              test/testdata/policy-controller/tester/cip-public-keyless.yaml \
-              ghcr.io/sigstore/cosign/cosign:v1.9.0 | jq)
+              --policy=test/testdata/policy-controller/tester/cip-public-keyless.yaml \
+              --image=ghcr.io/sigstore/cosign/cosign:v1.9.0 | jq)

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ policyControllerImagerefs
 policyImagerefs
 
 **verify-experimental*
+
+policy-tester

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ policy-controller: policy-webhook
 policy-webhook: ## Build the policy webhook binary
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./cmd/policy_webhook
 
+## Build policy-tester binary
+.PHONY: policy-tester
+policy-tester:
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./cmd/tester
+
 #####################
 # lint / test section
 #####################

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Then run it pointing to a YAML file containing a ClusterImagePolicy, and an imag
 ```
 (set -o pipefail && \
     ./policy-tester \
-        test/testdata/policy-controller/tester/cip-public-keyless.yaml \
-        ghcr.io/sigstore/cosign/cosign:v1.9.0 | jq)
+        --policy=test/testdata/policy-controller/tester/cip-public-keyless.yaml \
+        --image=ghcr.io/sigstore/cosign/cosign:v1.9.0 | jq)
 ```
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ Kubernetes webhook for configuring admission policies.
 
 (TODO: vaikas) Update this README
 
+## ClusterImagePolicy Testing
+
+This repo includes a `policy-tester` tool which enables checking a policy against
+various images.
+
+In the root of this repo, run the following to build:
+```
+make policy-tester
+```
+
+Then run it pointing to a YAML file containing a ClusterImagePolicy, and an image to evaluate the policy against:
+```
+(set -o pipefail && \
+    ./policy-tester \
+        test/testdata/policy-controller/tester/cip-public-keyless.yaml \
+        ghcr.io/sigstore/cosign/cosign:v1.9.0 | jq)
+```
+
 ## Security
 
 Should you discover any security issues, please refer to sigstores [security

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -74,11 +74,12 @@ func main() {
 
 	// TODO(jdolitsky): This should use v1beta1 once there exists a
 	// webhookcip.ConvertClusterImagePolicyV1beta1ToWebhook() method
-	var tmp v1alpha1.ClusterImagePolicy
-	if err := yaml.Unmarshal(cipRaw, &tmp); err != nil {
+	var v1alpha1cip v1alpha1.ClusterImagePolicy
+	if err := yaml.Unmarshal(cipRaw, &v1alpha1cip); err != nil {
 		log.Fatal(err)
 	}
-	cip := webhookcip.ConvertClusterImagePolicyV1alpha1ToWebhook(&tmp)
+	v1alpha1cip.SetDefaults(ctx)
+	cip := webhookcip.ConvertClusterImagePolicyV1alpha1ToWebhook(&v1alpha1cip)
 	ref, err := name.ParseReference(*image)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -1,0 +1,101 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/yaml"
+
+	"github.com/sigstore/policy-controller/pkg/apis/policy/v1alpha1"
+	"github.com/sigstore/policy-controller/pkg/webhook"
+	webhookcip "github.com/sigstore/policy-controller/pkg/webhook/clusterimagepolicy"
+)
+
+var (
+	ns = "unused"
+
+	remoteOpts = []ociremote.Option{
+		ociremote.WithRemoteOptions(
+			remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		),
+	}
+
+	ctx = logging.WithLogger(context.Background(), func() *zap.SugaredLogger {
+		x, _ := zap.NewDevelopmentConfig().Build()
+		return x.Sugar()
+	}())
+)
+
+type output struct {
+	Errors []string              `json:"errors"`
+	Result *webhook.PolicyResult `json:"result"`
+}
+
+func main() {
+	args := os.Args[1:]
+	if len(args) != 2 {
+		fmt.Println("Usage: policy-tester cluster-image-policy.yaml r.example.com/myrepo/myimage:mytag")
+		os.Exit(1)
+	}
+	cipFilePath := args[0]
+	image := args[1]
+	cipRaw, err := ioutil.ReadFile(cipFilePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// TODO(jdolitsky): should this use v1beta1?
+	var tmp v1alpha1.ClusterImagePolicy
+	if err := yaml.Unmarshal(cipRaw, &tmp); err != nil {
+		log.Fatal(err)
+	}
+	cip := webhookcip.ConvertClusterImagePolicyV1alpha1ToWebhook(&tmp)
+	ref, err := name.ParseReference(image)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	result, errs := webhook.ValidatePolicy(ctx, ns, ref, *cip, remoteOpts...)
+	errStrings := []string{}
+	for _, err := range errs {
+		errStrings = append(errStrings, strings.Trim(err.Error(), "\n"))
+	}
+	o, err := json.Marshal(&output{
+		Errors: errStrings,
+		Result: result,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(string(o))
+	if len(errs) > 0 {
+		os.Exit(1)
+	}
+}

--- a/test/testdata/policy-controller/tester/cip-public-keyless.yaml
+++ b/test/testdata/policy-controller/tester/cip-public-keyless.yaml
@@ -1,0 +1,24 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: demo
+spec:
+  images:
+    - glob: "**"
+  authorities:
+  - keyless:
+      url: "https://fulcio.sigstore.dev"

--- a/test/testdata/policy-controller/tester/cip-public-keyless.yaml
+++ b/test/testdata/policy-controller/tester/cip-public-keyless.yaml
@@ -18,7 +18,7 @@ metadata:
   name: demo
 spec:
   images:
-    - glob: "**"
+    - glob: ghcr.io/sigstore/cosign/cosign:v1.9.0
   authorities:
   - keyless:
-      url: "https://fulcio.sigstore.dev"
+      url: https://fulcio.sigstore.dev


### PR DESCRIPTION
Adding a simple tool for validating ClusterImagePolicy resources against various images on the command line