### PR TITLE
Update k8s clusters test

### DIFF
--- a/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
+++ b/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
@@ -41,7 +41,7 @@ jobs:
     env:
       KNATIVE_VERSION: "1.1.0"
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.2.8"
+      SCAFFOLDING_RELEASE_VERSION: "v0.3.0"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
+++ b/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
@@ -32,11 +32,11 @@ jobs:
     strategy:
       matrix:
         k8s-version:
-        - v1.21.x
         - v1.22.x
         # Try without this one now, might have problems with job restartings
         # may require upstream changes.
         - v1.23.x
+        - v1.24.x
 
     env:
       KNATIVE_VERSION: "1.1.0"

--- a/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
+++ b/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
@@ -39,7 +39,7 @@ jobs:
         - v1.24.x
 
     env:
-      KNATIVE_VERSION: "1.1.0"
+      KNATIVE_VERSION: "1.5.0"
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
       SCAFFOLDING_RELEASE_VERSION: "v0.3.0"
       GO111MODULE: on

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -41,7 +41,7 @@ jobs:
     env:
       KNATIVE_VERSION: "1.1.0"
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.2.8"
+      SCAFFOLDING_RELEASE_VERSION: "v0.3.0"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -32,11 +32,11 @@ jobs:
     strategy:
       matrix:
         k8s-version:
-        - v1.21.x
         - v1.22.x
         # Try without this one now, might have problems with job restartings
         # may require upstream changes.
         - v1.23.x
+        - v1.24.x
 
     env:
       KNATIVE_VERSION: "1.1.0"

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -39,7 +39,7 @@ jobs:
         - v1.24.x
 
     env:
-      KNATIVE_VERSION: "1.1.0"
+      KNATIVE_VERSION: "1.5.0"
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
       SCAFFOLDING_RELEASE_VERSION: "v0.3.0"
       GO111MODULE: on

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -29,9 +29,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.21.x
         - v1.22.x
         - v1.23.x
+        - v1.24.x
 
     env:
       # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for


### PR DESCRIPTION
#### Summary
- remove v1.21 k8s which is deprecated and add v1.24
- update scafolding to use release v0.3.0
- update knative to use v1.5.0 release


#### Release Note

`NONE`

#### Documentation

`NONE`