### PR TITLE
Avoid test race condition.

### DIFF
--- a/test/e2e_test_cluster_image_policy.sh
+++ b/test/e2e_test_cluster_image_policy.sh
@@ -270,6 +270,10 @@ echo '::group:: Deploy ClusterImagePolicy With Key Signing'
 yq '. | .spec.authorities[0].key.data |= load_str("cosign-colocated-signing.pub")' \
   ./test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml | \
   kubectl apply -f -
+
+# Give the policy controller a moment to update the configmap
+# and pick up the change in the admission controller.
+sleep 5
 echo '::endgroup::'
 
 echo '::group:: test with key and keyless, authorities OR'
@@ -302,6 +306,10 @@ yq '. | .metadata.name = "image-policy-remote-source"
     | .spec.authorities[0].key.data |= load_str("cosign-remote-signing.pub")' \
   ./test/testdata/policy-controller/e2e/cip-key.yaml | \
   kubectl apply -f -
+
+# Give the policy controller a moment to update the configmap
+# and pick up the change in the admission controller.
+sleep 5
 echo '::endgroup::'
 
 echo '::group:: Sign demoimage with cosign remote key'
@@ -338,6 +346,10 @@ yq '. | .metadata.name = "image-policy-remote-source"
     | .spec.authorities[0] += {"source": [{"oci": env(KO_DOCKER_REPO)+"/remote-signature"}]}' \
   ./test/testdata/policy-controller/e2e/cip-key.yaml | \
   kubectl apply -f -
+
+# Give the policy controller a moment to update the configmap
+# and pick up the change in the admission controller.
+sleep 5
 echo '::endgroup::'
 
 echo '::group:: Verify with three CIP, one with correct Source set'

--- a/test/e2e_test_cluster_image_policy_with_attestations.sh
+++ b/test/e2e_test_cluster_image_policy_with_attestations.sh
@@ -159,7 +159,9 @@ echo '::endgroup::'
 # custom attestation. Let's now do it for 'keyful' one.
 echo '::group:: Create CIP that requires a keyful signature'
 yq '. | .spec.authorities[0].key.data |= load_str("cosign.pub")' ./test/testdata/policy-controller/e2e/cip-key.yaml | kubectl apply -f -
-# allow things to propagate
+
+# Give the policy controller a moment to update the configmap
+# and pick up the change in the admission controller.
 sleep 5
 echo '::endgroup::'
 
@@ -184,7 +186,9 @@ echo '::endgroup::'
 # keyful attestation, so let's add that requirement.
 echo '::group:: Create CIP that requires a keyful attestation'
 yq '. | .spec.authorities[0].key.data |= load_str("cosign.pub")' ./test/testdata/policy-controller/e2e/cip-key-with-attestations.yaml | kubectl apply -f -
-# allow things to propagate
+
+# Give the policy controller a moment to update the configmap
+# and pick up the change in the admission controller.
 sleep 5
 echo '::endgroup::'
 
@@ -223,7 +227,9 @@ echo '::endgroup::'
 # Note we have to bake in the inline data from the keys above
 echo '::group:: Add cip for two signatures and two attestations'
 yq '. | .spec.authorities[1].key.data |= load_str("cosign.pub") | .spec.authorities[3].key.data |= load_str("cosign.pub")' ./test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml | kubectl apply -f -
-# allow things to propagate
+
+# Give the policy controller a moment to update the configmap
+# and pick up the change in the admission controller.
 sleep 5
 echo '::endgroup::'
 


### PR DESCRIPTION
I was seeing a race running e2e tests where immediately after applying a policy we immediately expect it to be enforced, but it takes time to compile and distribute the policy configmap.

As I was copying this other places, I noticed that the sleeps already existed, so I added my more detailed comment to the instances I found.

cc @vaikas @hectorj2f 

#### Documentation
