### PR TITLE
Fix keyful handling in tester.

### DIFF
--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -94,6 +94,16 @@ func main() {
 		log.Fatalf("CIP is invalid: %s", validateErrs.Error())
 	}
 	cip := webhookcip.ConvertClusterImagePolicyV1alpha1ToWebhook(&v1alpha1cip)
+
+	// We have to marshal/unmarshal the CIP since that handles converting
+	// inlined Data into PublicKey objects that validator uses.
+	webhookCip, err := json.Marshal(cip)
+	if err != nil {
+		log.Fatalf("Failed to marshal the webhook cip: %s", err)
+	}
+	if err := json.Unmarshal(webhookCip, &cip); err != nil {
+		log.Fatalf("Failed to unmarshal the webhook CIP: %s", err)
+	}
 	ref, err := name.ParseReference(*image)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

#### Summary
@jdolitsky found in #108 that the tester was not handling the Keyful validation correctly. This was caused by us not 'round-tripping' the webhook cip, which in the Policy-Controller path is marshalled by the reconciler and unmarshalled before handing to the validator path. One thing the unmarshaller does is convert the inlined data blocks into crypto keys which is what the policy-controller validator uses.

So, this PR adds that round tripping before using the webhook cip.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Fix bug in tester which was not handling keyful signatures / attestations correctly.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->