### PR TITLE
Add two more example policies

### DIFF
--- a/.github/workflows/policy-tester-examples.yml
+++ b/.github/workflows/policy-tester-examples.yml
@@ -107,3 +107,23 @@ jobs:
         ../policy-tester \
           --policy policies/keyless-attestation-sbom-spdxjson.yaml \
           --image "${REF}"
+
+    # This example requires public Fulcio, only run on push to main
+    - if: ${{ github.event_name == 'push' }}
+      name: Example (signed-by-github-actions)
+      working-directory: ./src/github.com/${{ github.repository }}/examples
+      run: |
+        REF="localhost:5000/examples/signed-by-github-actions"
+
+        # Push an image
+        docker pull alpine
+        docker tag alpine "${REF}"
+        docker push "${REF}"
+
+        # Sign image
+        cosign sign "${REF}"
+
+        # Ensure the image satisfies the policy
+        ../policy-tester \
+          --policy policies/signed-by-github-actions.yaml \
+          --image "${REF}"

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ policyImagerefs
 **verify-experimental*
 
 policy-tester
+
+# Vim
+*.swp

--- a/examples/policies/signed-by-aws-kms-key.yaml
+++ b/examples/policies/signed-by-aws-kms-key.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Name: image-is-signed-by-aws-kms-key
+#
+# Description:
+#   Assert that images from are signed by a specific
+#   AWS KMS key
+#
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-is-signed-by-aws-kms-key
+spec:
+  images:
+  # All images
+  - glob: "**"
+  authorities:
+  - name: aws-kms
+    key:
+      # NB: the policy controller must have kms.DescribeKey, kms.GetPublicKey
+      # and kms.Verify IAM permissions on the relevant key.
+      kms: awskms:///arn:aws:kms:<< region >>:<< account id >>:key/<< key id >>

--- a/examples/policies/signed-by-github-actions.yaml
+++ b/examples/policies/signed-by-github-actions.yaml
@@ -1,0 +1,40 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Name: image-is-signed-by-github-actions
+#
+# Description:
+#   Assert that images are signed by a specific Github Actions
+#   workflow on the main branch.
+#
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-is-signed-by-github-actions
+spec:
+  images:
+  # All images in example repository matched
+  - glob: "**"
+  authorities:
+  - keyless:
+      # Signed by the public Fulcio certificate authority
+      url: https://fulcio.sigstore.dev
+      identities:
+      # Matches the Github Actions OIDC issuer
+      - issuer: https://token.actions.githubusercontent.com
+        # Matches a specific github workflow on main branch. Here we use the
+        # sigstore policy controller example testing workflow as an example.
+        subject: "https://github.com/sigstore/policy-controller/.github/workflows/policy-tester-examples.yml@refs/head/main"


### PR DESCRIPTION
#### Summary

Adds a Github actions and AWS KMS example to the example policies directory. This expands the current examples beyond SBOM stuff and shows some common signing patterns

#### Release Note

NONE

#### Documentation

Will possibly send these over to the sigstore docs if desired.