### PR TITLE
Add all of the current extensions.

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -481,6 +481,13 @@ func ociSignatureToPolicySignature(ctx context.Context, sigs []oci.Signature) []
 			ret = append(ret, PolicySignature{
 				Subject: csigs.CertSubject(cert),
 				Issuer:  ce.GetIssuer(),
+				GithubExtensions: GithubExtensions{
+					WorkflowTrigger: ce.GetCertExtensionGithubWorkflowTrigger(),
+					WorkflowSHA:     ce.GetExtensionGithubWorkflowSha(),
+					WorkflowName:    ce.GetCertExtensionGithubWorkflowName(),
+					WorkflowRepo:    ce.GetCertExtensionGithubWorkflowRepository(),
+					WorkflowRef:     ce.GetCertExtensionGithubWorkflowRef(),
+				},
 			})
 		} else {
 			// TODO(mattmoor): Is there anything we should encode for key-based?

--- a/pkg/webhook/validator_result.go
+++ b/pkg/webhook/validator_result.go
@@ -59,6 +59,25 @@ type PolicySignature struct {
 	Subject string `json:"subject"`
 	// Issure that was found to match on the Cert.
 	Issuer string `json:"issuer"`
-	// TODO(vaikas): Add all the Fulcio specific extensions here too.
-	// https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md
+
+	// GithubExtensions holds the Github-related OID extensions.
+	// See also: https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md
+	GithubExtensions `json:",inline"`
+}
+
+// GithubExtensions holds the Github-related OID extensions.
+// See also: https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md
+// NOTE: these field correlate with the names given in the cosign
+// CertExtensionMap and must be prefixed with "github" to avoid ambiguity.
+type GithubExtensions struct {
+	// OID: 1.3.6.1.4.1.57264.1.2
+	WorkflowTrigger string `json:"githubWorkflowTrigger,omitempty"`
+	// OID: 1.3.6.1.4.1.57264.1.3
+	WorkflowSHA string `json:"githubWorkflowSha,omitempty"`
+	// OID: 1.3.6.1.4.1.57264.1.4
+	WorkflowName string `json:"githubWorkflowName,omitempty"`
+	// OID: 1.3.6.1.4.1.57264.1.5
+	WorkflowRepo string `json:"githubWorkflowRepo,omitempty"`
+	// OID: 1.3.6.1.4.1.57264.1.6
+	WorkflowRef string `json:"githubWorkflowRef,omitempty"`
 }

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -1687,6 +1687,13 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 						"test-att": {{
 							Subject: "https://github.com/distroless/static/.github/workflows/release.yaml@refs/heads/main",
 							Issuer:  "https://token.actions.githubusercontent.com",
+							GithubExtensions: GithubExtensions{
+								WorkflowTrigger: "schedule",
+								WorkflowSHA:     "7e7572e578de7c51a2f1a1791f025cf315503aa2",
+								WorkflowName:    "Create Release",
+								WorkflowRepo:    "distroless/static",
+								WorkflowRef:     "refs/heads/main",
+							},
 						}},
 					},
 				},


### PR DESCRIPTION
This follows up my previous PR that started to access the Issuer/Subject metadata to also include all of the current cert extensions.

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Release Note

```release-note
Start to incorporate the cert extensions into the PolicySignature.
```

#### Documentation


cc @vaikas @jdolitsky @hectorj2f 