### PR TITLE
Include the predicate type and payload for attestations.

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -498,6 +498,10 @@ func ociSignatureToPolicySignature(ctx context.Context, sigs []oci.Signature) []
 	return ret
 }
 
+// attestation is used to accumulate the signature along with extracted and
+// validated metadata during validation to construct a list of
+// PolicyAttestations upon completion without needing to refetch any of the
+// parts.
 type attestation struct {
 	oci.Signature
 
@@ -505,7 +509,7 @@ type attestation struct {
 	Payload       []byte
 }
 
-func attestationToPolicyAttestation(ctx context.Context, atts []attestation) []PolicyAttestation {
+func attestationToPolicyAttestations(ctx context.Context, atts []attestation) []PolicyAttestation {
 	ret := make([]PolicyAttestation, 0, len(atts))
 	for _, att := range atts {
 		logging.FromContext(ctx).Debugf("Converting attestation %+v", att)
@@ -684,7 +688,7 @@ func ValidatePolicyAttestationsForAuthority(ctx context.Context, ref name.Refere
 		if len(checkedAttestations) == 0 {
 			return nil, fmt.Errorf("%w with type %s", cosign.ErrNoMatchingAttestations, wantedAttestation.PredicateType)
 		}
-		ret[wantedAttestation.Name] = attestationToPolicyAttestation(ctx, checkedAttestations)
+		ret[wantedAttestation.Name] = attestationToPolicyAttestations(ctx, checkedAttestations)
 	}
 	return ret, nil
 }

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -359,7 +359,7 @@ func ValidatePolicy(ctx context.Context, namespace string, ref name.Reference, c
 	type retChannelType struct {
 		name         string
 		static       bool
-		attestations map[string][]PolicySignature
+		attestations map[string][]PolicyAttestation
 		signatures   []PolicySignature
 		err          error
 	}
@@ -490,8 +490,53 @@ func ociSignatureToPolicySignature(ctx context.Context, sigs []oci.Signature) []
 				},
 			})
 		} else {
-			// TODO(mattmoor): Is there anything we should encode for key-based?
-			ret = append(ret, PolicySignature{})
+			ret = append(ret, PolicySignature{
+				// TODO(mattmoor): Is there anything we should encode for key-based?
+			})
+		}
+	}
+	return ret
+}
+
+type attestation struct {
+	oci.Signature
+
+	PredicateType string
+	Payload       []byte
+}
+
+func attestationToPolicyAttestation(ctx context.Context, atts []attestation) []PolicyAttestation {
+	ret := make([]PolicyAttestation, 0, len(atts))
+	for _, att := range atts {
+		logging.FromContext(ctx).Debugf("Converting attestation %+v", att)
+
+		if cert, err := att.Cert(); err == nil && cert != nil {
+			ce := cosign.CertExtensions{
+				Cert: cert,
+			}
+			ret = append(ret, PolicyAttestation{
+				PolicySignature: PolicySignature{
+					Subject: csigs.CertSubject(cert),
+					Issuer:  ce.GetIssuer(),
+					GithubExtensions: GithubExtensions{
+						WorkflowTrigger: ce.GetCertExtensionGithubWorkflowTrigger(),
+						WorkflowSHA:     ce.GetExtensionGithubWorkflowSha(),
+						WorkflowName:    ce.GetCertExtensionGithubWorkflowName(),
+						WorkflowRepo:    ce.GetCertExtensionGithubWorkflowRepository(),
+						WorkflowRef:     ce.GetCertExtensionGithubWorkflowRef(),
+					},
+				},
+				PredicateType: att.PredicateType,
+				Payload:       att.Payload,
+			})
+		} else {
+			ret = append(ret, PolicyAttestation{
+				PolicySignature: PolicySignature{
+					// TODO(mattmoor): Is there anything we should encode for key-based?
+				},
+				PredicateType: att.PredicateType,
+				Payload:       att.Payload,
+			})
 		}
 	}
 	return ret
@@ -550,7 +595,7 @@ func ValidatePolicySignaturesForAuthority(ctx context.Context, ref name.Referenc
 
 // ValidatePolicyAttestationsForAuthority takes the Authority and tries to
 // verify attestations against it.
-func ValidatePolicyAttestationsForAuthority(ctx context.Context, ref name.Reference, authority webhookcip.Authority, remoteOpts ...ociremote.Option) (map[string][]PolicySignature, error) {
+func ValidatePolicyAttestationsForAuthority(ctx context.Context, ref name.Reference, authority webhookcip.Authority, remoteOpts ...ociremote.Option) (map[string][]PolicyAttestation, error) {
 	name := authority.Name
 	var rekorClient *client.Rekor
 	var err error
@@ -608,11 +653,11 @@ func ValidatePolicyAttestationsForAuthority(ctx context.Context, ref name.Refere
 	// them.
 	// TODO(vaikas): Pretty inefficient here, figure out a better way if
 	// possible.
-	ret := make(map[string][]PolicySignature, len(authority.Attestations))
+	ret := make(map[string][]PolicyAttestation, len(authority.Attestations))
 	for _, wantedAttestation := range authority.Attestations {
 		// There's a particular type, so we need to go through all the verified
 		// attestations and make sure that our particular one is satisfied.
-		checkedAttestations := make([]oci.Signature, 0, len(verifiedAttestations))
+		checkedAttestations := make([]attestation, 0, len(verifiedAttestations))
 		for _, va := range verifiedAttestations {
 			attBytes, err := policy.AttestationToPayloadJSON(ctx, wantedAttestation.PredicateType, va)
 			if err != nil {
@@ -630,12 +675,16 @@ func ValidatePolicyAttestationsForAuthority(ctx context.Context, ref name.Refere
 			}
 			// Ok, so this passed aok, jot it down to our result set as
 			// verified attestation with the predicate type match
-			checkedAttestations = append(checkedAttestations, va)
+			checkedAttestations = append(checkedAttestations, attestation{
+				Signature:     va,
+				PredicateType: wantedAttestation.PredicateType,
+				Payload:       attBytes,
+			})
 		}
 		if len(checkedAttestations) == 0 {
 			return nil, fmt.Errorf("%w with type %s", cosign.ErrNoMatchingAttestations, wantedAttestation.PredicateType)
 		}
-		ret[wantedAttestation.Name] = ociSignatureToPolicySignature(ctx, checkedAttestations)
+		ret[wantedAttestation.Name] = attestationToPolicyAttestation(ctx, checkedAttestations)
 	}
 	return ret, nil
 }

--- a/pkg/webhook/validator_result.go
+++ b/pkg/webhook/validator_result.go
@@ -44,7 +44,7 @@ type AuthorityMatch struct {
 	Signatures []PolicySignature `json:"signatures,omitempty"`
 
 	// Mapping from attestation name to all of verified attestations
-	Attestations map[string][]PolicySignature `json:"attestations,omitempty"`
+	Attestations map[string][]PolicyAttestation `json:"attestations,omitempty"`
 
 	// Static indicates whether this authority matched due to static
 	// e.g. static: { action: pass }
@@ -63,6 +63,22 @@ type PolicySignature struct {
 	// GithubExtensions holds the Github-related OID extensions.
 	// See also: https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md
 	GithubExtensions `json:",inline"`
+}
+
+// PolicyAttestation contains a normalized result of a validated attestation,
+// which consists of the PolicySignature part, and some additional attestation
+// specific fields.
+type PolicyAttestation struct {
+	PolicySignature `json:",inline"`
+
+	// PredicateType is the in-toto predicate type of this attestation.
+	PredicateType string `json:"predicateType,omitempty"`
+
+	// Payload is the bytes of the in-toto statement's predicate payload.
+	// This is included for the benefit of the caller of ValidatePolicy, and is
+	// not intended for consumption in the ClusterImagePolicy's outer policy
+	// block.
+	Payload []byte `json:"-"`
 }
 
 // GithubExtensions holds the Github-related OID extensions.

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -1682,17 +1682,21 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 		want: &PolicyResult{
 			AuthorityMatches: map[string]AuthorityMatch{
 				"authority-0": {
-					Attestations: map[string][]PolicySignature{
+					Attestations: map[string][]PolicyAttestation{
 						"test-att": {{
-							Subject: "https://github.com/distroless/static/.github/workflows/release.yaml@refs/heads/main",
-							Issuer:  "https://token.actions.githubusercontent.com",
-							GithubExtensions: GithubExtensions{
-								WorkflowTrigger: "schedule",
-								WorkflowSHA:     "7e7572e578de7c51a2f1a1791f025cf315503aa2",
-								WorkflowName:    "Create Release",
-								WorkflowRepo:    "distroless/static",
-								WorkflowRef:     "refs/heads/main",
+							PolicySignature: PolicySignature{
+								Subject: "https://github.com/distroless/static/.github/workflows/release.yaml@refs/heads/main",
+								Issuer:  "https://token.actions.githubusercontent.com",
+								GithubExtensions: GithubExtensions{
+									WorkflowTrigger: "schedule",
+									WorkflowSHA:     "7e7572e578de7c51a2f1a1791f025cf315503aa2",
+									WorkflowName:    "Create Release",
+									WorkflowRepo:    "distroless/static",
+									WorkflowRef:     "refs/heads/main",
+								},
 							},
+							PredicateType: "vuln",
+							Payload:       []byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"cosign.sigstore.dev/attestation/vuln/v1","subject":[{"name":"ghcr.io/distroless/static","digest":{"sha256":"a1e82f6a5f6dfc735165d3442e7cc5a615f72abac3db19452481f5f3c90fbfa8"}}],"predicate":{"invocation":{"parameters":null,"uri":"https://github.com/distroless/static/actions/runs/2757953139","event_id":"2757953139","builder.id":"Create Release"},"scanner":{"uri":"https://github.com/aquasecurity/trivy","version":"0.29.2","db":{"uri":"","version":""},"result":{"$schema":"https://json.schemastore.org/sarif-2.1.0-rtm.5.json","runs":[{"columnKind":"utf16CodeUnits","originalUriBaseIds":{"ROOTPATH":{"uri":"file:///"}},"results":[],"tool":{"driver":{"fullName":"Trivy Vulnerability Scanner","informationUri":"https://github.com/aquasecurity/trivy","name":"Trivy","rules":[],"version":"0.29.2"}}}],"version":"2.1.0"}},"metadata":{"scanStartedOn":"2022-07-29T02:28:42Z","scanFinishedOn":"2022-07-29T02:28:48Z"}}}`),
 						}},
 					},
 				},


### PR DESCRIPTION
This change factors a new `PolicyAttestation` type so that we can encode additional information for attestations beyond just signature fields.

This change adds the predicate type (which would otherwise require parsing the CIP to know), and the payload (included for callers of ValidatePolicy, so they don't have to refetch the `oci.Signature`'s `Payload()`).

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Release Note

The policy results for attestations now includes the predicate type (available to CIP policies) and the attestation payload (not available to CIP policies since we've already run the policy over them).  To achieve this, there is a potentially breaking change to the signature of `ValidatePolicy` to wrap the attestation's `PolicySignature` in a new `PolicyAttestation` type, however, to minimize disruption `PolicyAttestation` inlines `PolicySignature`.

#### Documentation


cc @hectorj2f @vaikas 