### PR TITLE
Add warn tests for creating CIP with missing identities.

### DIFF
--- a/test/e2e_test_cluster_image_policy.sh
+++ b/test/e2e_test_cluster_image_policy.sh
@@ -18,8 +18,8 @@
 set -ex
 
 if [[ -z "${OIDC_TOKEN}" ]]; then
-  if [[ -z "${TOKEN_ISSUER}" ]]; then
-    echo "Must specify either env variable OIDC_TOKEN or TOKEN_ISSUER"
+  if [[ -z "${ISSUER_URL}" ]]; then
+    echo "Must specify either env variable OIDC_TOKEN or ISSUER_URL"
     exit 1
   else
     export OIDC_TOKEN=`curl -s ${ISSUER_URL}`

--- a/test/e2e_test_cluster_image_policy_with_attestations.sh
+++ b/test/e2e_test_cluster_image_policy_with_attestations.sh
@@ -18,8 +18,8 @@
 set -ex
 
 if [[ -z "${OIDC_TOKEN}" ]]; then
-  if [[ -z "${TOKEN_ISSUER}" ]]; then
-    echo "Must specify either env variable OIDC_TOKEN or TOKEN_ISSUER"
+  if [[ -z "${ISSUER_URL}" ]]; then
+    echo "Must specify either env variable OIDC_TOKEN or ISSUER_URL"
     exit 1
   else
     export OIDC_TOKEN=`curl -s ${ISSUER_URL}`

--- a/test/e2e_test_cluster_image_policy_with_warn.sh
+++ b/test/e2e_test_cluster_image_policy_with_warn.sh
@@ -18,8 +18,8 @@
 set -ex
 
 if [[ -z "${OIDC_TOKEN}" ]]; then
-  if [[ -z "${TOKEN_ISSUER}" ]]; then
-    echo "Must specify either env variable OIDC_TOKEN or TOKEN_ISSUER"
+  if [[ -z "${ISSUER_URL}" ]]; then
+    echo "Must specify either env variable OIDC_TOKEN or ISSUER_URL"
     exit 1
   else
     export OIDC_TOKEN=`curl -s ${ISSUER_URL}`

--- a/test/e2e_test_policy_crd.sh
+++ b/test/e2e_test_policy_crd.sh
@@ -20,15 +20,30 @@ set -o pipefail
 
 # This script will iterate over expected failures for invalid CIPs in
 # ./test/testdata/policy-controller/invalid
-# Each of the CIP can specify a line that looks like this:
+# Each of the CIP specifies a line that looks like this:
 # ERROR:expected error goes here
 # And for each invalid CIP, the error is validated to be the expected failure.
 # You can have multiple ERROR lines and then each one will be matched.
 # Note that we grep with the exact match so as not to get bamboozled by the
 # grep regexp rules. This allows us to match fields in arrays (like
-# authority[0]) for example.
+# authorities[0].keyless.identities) for example.
 
-# We only want to loop over error lines, not words.
+# We the iterate over expected successes but with failures for "warn" CIPs in
+# ./test/testdata/policy-controller/warn
+# Each of the CIP specifies a line that looks like this:
+# Warning: missing field(s): spec.authorities[0].keyless.identities
+# And for each "warn" CIP, the warning is validated and we make sure the
+# CIP is still admitted and therefore it's only a warning.
+# Note that we grep with the exact match so as not to get bamboozled by the
+# grep regexp rules. This allows us to match fields in arrays (like
+# authorities[0].keyless.identities) for example.
+
+# Finally we loop over good CIPs in
+# ./test/testdata/policy-controller/valid
+# Each of the CIP is expected to succeed and we error out if it fails to be
+# created.
+
+# We only want to loop over error / warning lines, not words.
 IFS=$'\n'
 echo '::group:: Invalid policy tests:'
 for i in `ls ./test/testdata/policy-controller/invalid/`
@@ -55,6 +70,34 @@ do
   fi
 done
 echo '::endgroup:: Invalid policy test:'
+
+echo '::group:: Warning policy tests:'
+for i in `ls ./test/testdata/policy-controller/warn/`
+do
+  echo Testing: $i
+  # Grab the expected error from the CIP
+  expected_warnings=$(grep Warning: test/testdata/policy-controller/warn/${i} | cut -d ' ' -f 2-)
+  warn_file="./kubectl_warn"
+  if ! kubectl create -f ./test/testdata/policy-controller/warn/$i 2> ${warn_file}; then
+    echo "${i} policy rejected when it should have only warned"
+    cat ${warn_file}
+    exit 1
+  else
+    for expected_warning in ${expected_warnings}
+    do
+      echo looking for warning: ${expected_warning}
+      if ! grep --fixed-strings -q "${expected_warning}" ${warn_file} ; then
+        echo Did not get expected warning message, wanted "${expected_warning}", got
+        cat ${warn_file}
+        exit 1
+      else
+        echo "${i} created and warning found as expected"
+      fi
+    done
+  fi
+  kubectl delete -f ./test/testdata/policy-controller/warn/$i --ignore-not-found=true
+done
+echo '::endgroup:: Warning policy test:'
 
 echo '::group:: Valid policy test:'
 for i in `ls ./test/testdata/policy-controller/valid/`

--- a/test/testdata/policy-controller/warn/missing-identity.yaml
+++ b/test/testdata/policy-controller/warn/missing-identity.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: missing field(s): spec.authorities[0].keyless.identities
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-missing-identity
+spec:
+  mode: warn
+  images:
+  - glob: "**"
+  authorities:
+  - keyless:
+      url: https://fulcio.sigstore.dev

--- a/test/testdata/policy-controller/warn/missing-issuer.yaml
+++ b/test/testdata/policy-controller/warn/missing-issuer.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-missing-issuer
+spec:
+  mode: warn
+  images:
+  - glob: "**"
+  authorities:
+  - keyless:
+      url: https://fulcio.sigstore.dev
+      identities:
+      - subject: "testsubject"

--- a/test/testdata/policy-controller/warn/missing-subject.yaml
+++ b/test/testdata/policy-controller/warn/missing-subject.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-missing-subject
+spec:
+  mode: warn
+  images:
+  - glob: "**"
+  authorities:
+  - keyless:
+      url: https://fulcio.sigstore.dev
+      identities:
+      - issuer: "testissuer"

--- a/test/testdata/policy-controller/warn/v1beta1-missing-identity.yaml
+++ b/test/testdata/policy-controller/warn/v1beta1-missing-identity.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: missing field(s): spec.authorities[0].keyless.identities
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-missing-identity-v1beta1
+spec:
+  mode: warn
+  images:
+  - glob: "**"
+  authorities:
+  - keyless:
+      url: https://fulcio.sigstore.dev

--- a/test/testdata/policy-controller/warn/v1beta1-missing-issuer.yaml
+++ b/test/testdata/policy-controller/warn/v1beta1-missing-issuer.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-missing-issuer-v1beta1
+spec:
+  mode: warn
+  images:
+  - glob: "**"
+  authorities:
+  - keyless:
+      url: https://fulcio.sigstore.dev
+      identities:
+      - subject: "testsubject"

--- a/test/testdata/policy-controller/warn/v1beta1-missing-subject.yaml
+++ b/test/testdata/policy-controller/warn/v1beta1-missing-subject.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-missing-subject-v1beta1
+spec:
+  mode: warn
+  images:
+  - glob: "**"
+  authorities:
+  - keyless:
+      url: https://fulcio.sigstore.dev
+      identities:
+      - issuer: "testissuer"


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Add tests for making sure that when we create CIPs that warnings are produced and they match what we expect.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->