### PR TITLE
update CIP to fix tests when running in the push to main and in keyless mode

### DIFF
--- a/examples/policies/keyless-attestation-sbom-spdxjson.yaml
+++ b/examples/policies/keyless-attestation-sbom-spdxjson.yaml
@@ -32,6 +32,9 @@ spec:
   - name: keyless
     keyless:
       url: "https://fulcio.sigstore.dev"
+      identities:
+        - issuer: https://token.actions.githubusercontent.com
+          subject: "https://github.com/sigstore/policy-controller/.github/workflows/policy-tester-examples.yml@refs/heads/main"
     attestations:
     - name: must-have-spdxjson
       predicateType: spdxjson


### PR DESCRIPTION
#### Summary
- update CIP to fix tests when running in the push to main and in keyless mode

```
main.go:93: Using the following cip:
apiVersion: policy.sigstore.dev/v1alpha1
kind: ClusterImagePolicy
metadata:
  creationTimestamp: null
  name: keyless-attestation-sbom-spdxjson
spec:
  authorities:
  - attestations:
    - name: must-have-spdxjson
      policy:
        data: |
          predicateType: "https://spdx.dev/Document"
        type: cue
      predicateType: spdxjson
    keyless:
      url: https://fulcio.sigstore.dev/
    name: keyless
  images:
  - glob: '**'
  mode: enforce
main.go:97: CIP is invalid: missing field(s): spec.authorities[0].keyless.identities
Error: Process completed with exit code 1.
```

see https://github.com/sigstore/policy-controller/runs/8058669693?check_suite_focus=true

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->