### PR TITLE
Do not exit on warnings on CIP.

### DIFF
--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -94,7 +94,14 @@ func main() {
 
 	validateErrs := v1alpha1cip.Validate(ctx)
 	if validateErrs != nil {
-		log.Fatalf("CIP is invalid: %s", validateErrs.Error())
+		// CIP validation can return Warnings so let's just go through them
+		// and only exit if there are Errors.
+		if warnFE := validateErrs.Filter(apis.WarningLevel); warnFE != nil {
+			log.Printf("CIP has warnings:\n%s\n", warnFE.Error())
+		}
+		if errorFE := validateErrs.Filter(apis.ErrorLevel); errorFE != nil {
+			log.Fatalf("CIP is invalid: %s", errorFE.Error())
+		}
 	}
 	cip := webhookcip.ConvertClusterImagePolicyV1alpha1ToWebhook(&v1alpha1cip)
 


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
As seen on #195 the tester would exit on `warning` level validation errors. So, split out the warnings and print them
separately and do not exit on them.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->