### PR TITLE
Add e2e test with secretRef.

### DIFF
--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
@@ -189,7 +189,7 @@ func getKMSPublicKey(ctx context.Context, keyID string) (string, error) {
 // is modified.
 // There's still some discussion about how to handle multiple keys in a secret
 // for now, just grab one from it. For reference, the discussion is here:
-// TODO(vaikas): https://github.com/sigstore/policy-controller/issues/1573
+// TODO(vaikas): https://github.com/sigstore/cosign/issues/1573
 func (r *Reconciler) inlineAndTrackSecret(ctx context.Context, cip *v1alpha1.ClusterImagePolicy, keyref *v1alpha1.KeyRef) error {
 	if err := r.tracker.TrackReference(tracker.Reference{
 		APIVersion: "v1",

--- a/test/testdata/policy-controller/e2e/cip-key-secret.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-secret.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: cip-key-secret
+spec:
+  images:
+  - glob: "**demo**"
+  authorities:
+  - key:
+      secretRef:
+        name: cip-secret
+    ctlog:
+      url: http://rekor.rekor-system.svc


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Add e2e test using key.secretRef.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->