### PR TITLE
Relax glob so easier to run e2e tests against other clusters.

### DIFF
--- a/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
@@ -21,7 +21,7 @@ metadata:
   name: image-policy-key
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - key:
       data: |

--- a/test/testdata/policy-controller/e2e/cip-key-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-with-attestations.yaml
@@ -18,7 +18,7 @@ metadata:
   name: image-policy-key-with-attestations
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - name: verify custom attestation
     key:

--- a/test/testdata/policy-controller/e2e/cip-key.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key.yaml
@@ -18,13 +18,13 @@ metadata:
   name: image-policy-key
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - key:
       data: |
         -----BEGIN PUBLIC KEY-----
-        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZxAfzrQG1EbWyCI8LiSB7YgSFXoI
-        FNGTyQGKHFc6/H8TQumT9VLS78pUwtv3w7EfKoyFZoP32KrO7nzUy2q6Cw==
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIcbqK2RAVZOfPzo+kbOhNYq8DK9f
+        B2BGbU7jAXEvYthJ3vRcYq8l7g9UAXXiz9P2awFuTa4COcZU2IdEDVU0uA==
         -----END PUBLIC KEY-----
     ctlog:
       url: http://rekor.rekor-system.svc

--- a/test/testdata/policy-controller/e2e/cip-keyless-warn.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-warn.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   mode: warn
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - keyless:
       url: http://fulcio.fulcio-system.svc

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
@@ -18,7 +18,7 @@ metadata:
   name: image-policy-keyless-with-attestations
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - name: attestation
     keyless:

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-identities-mismatch.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-identities-mismatch.yaml
@@ -18,7 +18,7 @@ metadata:
   name: image-policy-keyless-with-identities-mismatch
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - keyless:
       url: http://fulcio.fulcio-system.svc

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-identities.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-identities.yaml
@@ -18,7 +18,7 @@ metadata:
   name: image-policy-keyless-with-identities
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - keyless:
       url: http://fulcio.fulcio-system.svc

--- a/test/testdata/policy-controller/e2e/cip-keyless.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless.yaml
@@ -18,7 +18,7 @@ metadata:
   name: image-policy-keyless
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - keyless:
       url: http://fulcio.fulcio-system.svc

--- a/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml
@@ -18,7 +18,7 @@ metadata:
   name: image-policy-requires-two-signatures-two-attestations
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - name: keylessatt
     keyless:

--- a/test/testdata/policy-controller/e2e/cip-static-fail.yaml
+++ b/test/testdata/policy-controller/e2e/cip-static-fail.yaml
@@ -18,7 +18,7 @@ metadata:
   name: image-policy-static-fail
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - static:
       action: fail

--- a/test/testdata/policy-controller/e2e/cip-static-pass.yaml
+++ b/test/testdata/policy-controller/e2e/cip-static-pass.yaml
@@ -18,7 +18,7 @@ metadata:
   name: image-policy-static-pass
 spec:
   images:
-  - glob: registry.local:5000/policy-controller/demo*
+  - glob: "**demo**"
   authorities:
   - static:
       action: pass


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

When doing e2e tests against existing clusters like gke, I find it easier to use different registries. So relax the glob so they just work.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->