### PR TITLE
Start deprecation of --secret-name

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -47,7 +47,8 @@ import (
 	cwebhook "github.com/sigstore/policy-controller/pkg/webhook"
 )
 
-var secretName = flag.String("secret-name", "", "The name of the secret in the webhook's namespace that holds the public key for verification.")
+// Deprecated: this flag will be removed in the future
+var secretName = flag.String("secret-name", "", "Flag -secret-name has been deprecated and will be removed in the future. The name of the secret in the webhook's namespace that holds the public key for verification.")
 
 // webhookName holds the name of the validating and mutating webhook
 // configuration resources dispatching admission requests to policy-controller.

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -45,6 +45,7 @@ spec:
         # and substituted here.
         image: ko://github.com/sigstore/policy-controller/cmd/webhook
         args: [
+          # DEPRECATED: -secret-name will be removed in the future.
           "-secret-name=verification-key",
           # Uncomment these to initialize with a custom TUF root.
           # TODO: How to specify the entire TUF directory for multiple


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

The intention is to remove a flag that has been added with our first alpha version but it does not fit anymore in our declarative way of defining policies and authorities. 

Following the Kubernetes deprecation policy for flags and beta versions, we will remove this flag in one release.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Add a deprecation message to remove the -secret-name flag in the future.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->