### PR TITLE
remove double quotes, looks like it is passing as a single string to cosign and not as an array

### DIFF
--- a/release/ko-sign-release-images.sh
+++ b/release/ko-sign-release-images.sh
@@ -32,5 +32,5 @@ if [[ ! -f policyImagerefs ]]; then
 fi
 
 echo "Signing images with Keyless..."
-cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat policyControllerImagerefs)"
-cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat policyImagerefs)"
+cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat policyControllerImagerefs)
+cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat policyImagerefs)


### PR DESCRIPTION
#### Summary
- `ko` now output more digests (before 0.11.2 release the output was just one) and that was passing as a unique big string to cosign failing the job

