### PR TITLE
Allow fetching CIPs from URLs.

### DIFF
--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 
@@ -63,7 +64,7 @@ type output struct {
 }
 
 func main() {
-	cipFilePath := flag.String("policy", "", "path to ClusterImagePolicy")
+	cipFilePath := flag.String("policy", "", "path to ClusterImagePolicy or URL to fetch from (http/https)")
 	image := flag.String("image", "", "image to compare against policy")
 	flag.Parse()
 	if *cipFilePath == "" || *image == "" {
@@ -71,9 +72,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	cipRaw, err := ioutil.ReadFile(*cipFilePath)
-	if err != nil {
-		log.Fatal(err)
+	var cipRaw []byte
+	var err error
+	if strings.HasPrefix(*cipFilePath, "https://") || strings.HasPrefix(*cipFilePath, "http://") {
+		log.Printf("Fetching CIP from: %s", *cipFilePath)
+		resp, err := http.Get(*cipFilePath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		cipRaw, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		cipRaw, err = ioutil.ReadFile(*cipFilePath)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	// TODO(jdolitsky): This should use v1beta1 once there exists a

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -80,13 +80,13 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		defer resp.Body.Close()
-		cipRaw, err = ioutil.ReadAll(resp.Body)
+		cipRaw, err = io.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		cipRaw, err = ioutil.ReadFile(*cipFilePath)
+		cipRaw, err = os.ReadFile(*cipFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -18,8 +18,8 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"log"
+	"os"
 
 	policyduckv1beta1 "github.com/sigstore/policy-controller/pkg/apis/duck/v1beta1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -81,7 +81,7 @@ func main() {
 	var tufRootBytes []byte
 	var err error
 	if *tufRoot != "" {
-		tufRootBytes, err = ioutil.ReadFile(*tufRoot)
+		tufRootBytes, err = os.ReadFile(*tufRoot)
 		if err != nil {
 			logging.FromContext(ctx).Panicf("Failed to read alternate TUF root file %s : %v", *tufRoot, err)
 		}

--- a/examples/policies/release-signed-by-github-actions.yaml
+++ b/examples/policies/release-signed-by-github-actions.yaml
@@ -1,0 +1,40 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Name: release-signed-by-github-actions
+#
+# Description:
+#   Assert that a policy-controller release was signed by expected subject
+#   and issuer.
+#
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-is-signed-by-github-actions
+spec:
+  images:
+  # This is the release v0.3.0
+  - glob: "gcr.io/projectsigstore/policy-webhook@sha256:d1e7af59381793687db4673277005276eb73a06cf555503138dd18eaa1ca47d6"
+  authorities:
+  - keyless:
+      # Signed by the public Fulcio certificate authority
+      url: https://fulcio.sigstore.dev
+      identities:
+      # Matches the Github Actions OIDC issuer
+      - issuer: https://token.actions.githubusercontent.com
+        # Matches a specific github workflow on main branch. Here we use the
+        # sigstore policy controller example testing workflow as an example.
+        subject: "https://github.com/sigstore/policy-controller/.github/workflows/release.yaml@refs/tags/v0.3.0"


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Sometimes it's handy to not fetch the CIP from the file, but for example by hosting the CIP for example on a website.
So, treat the -policy so that if it starts with https:// or http:// it will fetch it.

Example invocation:
```
./tester -policy="https://raw.githubusercontent.com/sigstore/policy-controller/main/examples/policies/signed-by-github-actions.yaml" -image=gcr.io/projectsigstore/policy-webhook@sha256:d1e7af59381793687db4673277005276eb73a06cf555503138dd18eaa1ca47d6
```

Which fails with the expected, issuer does not match because tester uses main, but the released Subject is:
```
https://github.com/sigstore/policy-controller/.github/workflows/release.yaml@refs/tags/v0.3.0
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->