### PR TITLE
add tester binary to the release process

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,64 @@ before:
     - /bin/bash -c 'make build-sign-release-images'
 
 builds:
-  - skip: true
+  - id: tester
+    binary: tester-{{ .Os }}-{{ .Arch }}
+    no_unique_dist_dir: true
+    main: ./cmd/tester/main.go
+    flags:
+      - -trimpath
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - s390x
+      - ppc64le
+    goarm:
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: s390x
+      - goos: windows
+        goarch: ppc64le
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    env:
+      - CGO_ENABLED=0
+
+signs:
+  # Keyless
+  - id: tester
+    signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
+    cmd: cosign
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
+    artifacts: binary
+  - id: checksum-keyless
+    signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
+    cmd: cosign
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
+    artifacts: checksum
+
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}"
+    allow_different_binary_count: true
+
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
 
 release:
   prerelease: allow # remove this when we start publishing non-prerelease or set to auto

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/zap"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
+	"sigs.k8s.io/release-utils/version"
 	"sigs.k8s.io/yaml"
 
 	"github.com/sigstore/policy-controller/pkg/apis/glob"
@@ -65,8 +66,16 @@ type output struct {
 
 func main() {
 	cipFilePath := flag.String("policy", "", "path to ClusterImagePolicy or URL to fetch from (http/https)")
+	versionFlag := flag.Bool("version", false, "return the policy-controller tester version")
 	image := flag.String("image", "", "image to compare against policy")
 	flag.Parse()
+
+	if *versionFlag {
+		v := version.GetVersionInfo()
+		fmt.Println(v.String())
+		os.Exit(0)
+	}
+
 	if *cipFilePath == "" || *image == "" {
 		flag.Usage()
 		os.Exit(1)

--- a/release/release.mk
+++ b/release/release.mk
@@ -6,6 +6,11 @@
 release:
 	LDFLAGS="$(LDFLAGS)" goreleaser release --timeout 120m
 
+# used when releasing together with GCP CloudBuild
+.PHONY: snapshot
+snapshot:
+	LDFLAGS="$(LDFLAGS)" goreleaser release --rm-dist --snapshot --skip-sign --timeout 120m
+
 ######################
 # sign section
 ######################


### PR DESCRIPTION
#### Summary
- add version flag
- add tester binary to the release process

Fixes: https://github.com/sigstore/policy-controller/issues/232