### PR TITLE
deny by default.

### DIFF
--- a/config/config-policy-controller.yaml
+++ b/config/config-policy-controller.yaml
@@ -18,4 +18,4 @@ metadata:
   name: config-policy-controller
   namespace: cosign-system
 data:
-  no-match-policy: allow
+  no-match-policy: deny

--- a/test/e2e_test_cluster_image_policy_with_warn.sh
+++ b/test/e2e_test_cluster_image_policy_with_warn.sh
@@ -154,13 +154,13 @@ echo '::endgroup::'
 # Change to an image that does not match any policies
 demoimage2="quay.io/jetstack/cert-manager-acmesolver:v1.9.1"
 
-# Then test the unmatched policy behaviour with default, which is allow
-echo '::group:: test no-match policy allow'
-if ! kubectl create -n demo-keyless-signing job demo-works --image=${demoimage2} ; then
-  echo Failed to create Job in namespace with no matching policies, but allow
+# Then test the unmatched policy behaviour with default, which is deny
+echo '::group:: test no-match default policy, which is deny'
+if kubectl create -n demo-keyless-signing job demo-should-not-work --image=${demoimage2} ; then
+  echo Failed to block Job with no matching policy and default deny
   exit 1
 else
-  echo Succcessfully created Job because no matching policy and allow
+  echo Successfully blocked Job in namespace with no matching policies, and deny
 fi
 echo '::endgroup::'
 
@@ -178,21 +178,21 @@ expected_warn='Warning: no matching policies:'
 assert_warning ${expected_warn}
 echo '::endgroup::'
 
-echo '::group:: Change no-match policy to deny'
+echo '::group:: Change no-match policy to allow'
 kubectl patch configmap/config-policy-controller \
   --namespace cosign-system \
   --type merge \
-  --patch '{"data":{"no-match-policy":"deny"}}'
+  --patch '{"data":{"no-match-policy":"allow"}}'
 # allow for propagation
 sleep 5
 echo '::endgroup::'
 
-echo '::group:: test no-match policy deny'
-if kubectl create -n demo-keyless-signing job demo-should-not-work --image=${demoimage2} ; then
-  echo Failed to block Job with no matching policy and deny
+echo '::group:: test no-match policy allow'
+if ! kubectl create -n demo-keyless-signing job demo-works --image=${demoimage2} ; then
+  echo Failed to create Job in namespace with no matching policies, but allow
   exit 1
 else
-  echo Successfully blocked Job in namespace with no matching policies, and deny
+  echo Succcessfully created Job because no matching policy and allow
 fi
 echo '::endgroup::'
 


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
fixed #235 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Any image not matching a policy is 'deny' by default.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->