### PR TITLE
add id-token permission to be able to sign the report

### DIFF
--- a/.github/workflows/scorecard_action.yml
+++ b/.github/workflows/scorecard_action.yml
@@ -20,6 +20,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      id-token: write
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION


#### Summary
- add id-token permission to be able to sign the report