### PR TITLE
Fix: Check flag in v1alpha1, use OrDefaults to avoid breaking change.

### DIFF
--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -28,6 +28,8 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
+
+	policycontrollerconfig "github.com/sigstore/policy-controller/pkg/config"
 )
 
 const awsKMSPrefix = "awskms://"
@@ -52,13 +54,16 @@ func (c *ClusterImagePolicy) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (spec *ClusterImagePolicySpec) Validate(ctx context.Context) (errors *apis.FieldError) {
+	// Check what the configuration is and act accordingly.
+	pcConfig := policycontrollerconfig.FromContextOrDefaults(ctx)
+
 	if len(spec.Images) == 0 {
 		errors = errors.Also(apis.ErrMissingField("images"))
 	}
 	for i, image := range spec.Images {
 		errors = errors.Also(image.Validate(ctx).ViaFieldIndex("images", i))
 	}
-	if len(spec.Authorities) == 0 {
+	if len(spec.Authorities) == 0 && pcConfig.FailOnEmptyAuthorities {
 		errors = errors.Also(apis.ErrMissingField("authorities"))
 	}
 	for i, authority := range spec.Authorities {

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -55,7 +55,7 @@ func (c *ClusterImagePolicy) Validate(ctx context.Context) *apis.FieldError {
 
 func (spec *ClusterImagePolicySpec) Validate(ctx context.Context) (errors *apis.FieldError) {
 	// Check what the configuration is and act accordingly.
-	pcConfig := policycontrollerconfig.FromContext(ctx)
+	pcConfig := policycontrollerconfig.FromContextOrDefaults(ctx)
 
 	if len(spec.Images) == 0 {
 		errors = errors.Also(apis.ErrMissingField("images"))


### PR DESCRIPTION
:bug: The addition of the new config to v1beta1 without `OrDefaults` is breaking (segfault!) to downstream callers of `Validate()`, so this changes things to use `OrDefaults` for when that configuration is unavailable.
:bug: I also noticed that the v1alpha1 validation wasn't checking the config, so depending on the version we validate with this is breaking, which creates some weird semantics with conversion.

This makes things use `OrDefaults` and copies the logic to `v1alpha1`.

/kind bug

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Release Note

#### Documentation

