### PR TITLE
switch to reusable workflow for license/vuln scan

### DIFF
--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -20,9 +20,5 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout Repository'
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@fd675ced9c17f1393071e1a2e685ab527e585a0c # v2
+    name: License and Vulnerability Scan
+    uses: sigstore/community/.github/workflows/reusable-dependency-review.yml@9b1b5aca605f92ec5b1bf3681b1e61b3dbc420cc


### PR DESCRIPTION
Per https://github.com/sigstore/TSC/issues/34 moving to a common workflow across projects

Signed-off-by: Bob Callaway <bcallaway@google.com>