### PR TITLE
Add validation for the oci repository field

### DIFF
--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -636,8 +636,23 @@ func TestAuthoritiesValidation(t *testing.T) {
 			},
 		},
 		{
+			name:        "Should fail with invalid AWS KMS for Keyful",
+			errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].key.kms\nfailed to parse either key or alias arn: arn: not enough sections",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "awskms://localhost:8888/arn:butnotvalid"},
+							Sources: []Source{{OCI: "registry.example.com"}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:        "Should fail with invalid OCI value",
-			errorString: "invalid value: registry.example.com/repo/*: spec.authorities[0].source[0].oci\ncan only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`",
+			errorString: "invalid value: registry.example.com/repo/*: spec.authorities[0].source[0].oci\nrepository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: repo/*",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{{Glob: "gcr.io/*"}},
@@ -645,6 +660,35 @@ func TestAuthoritiesValidation(t *testing.T) {
 						{
 							Key:     &KeyRef{KMS: "kms://key/path"},
 							Sources: []Source{{OCI: "registry.example.com/repo/*"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Should fail with invalid OCI value usign wrong characters",
+			errorString: "invalid value: re@gistry/reponame: spec.authorities[0].source[0].oci\nregistries must be valid RFC 3986 URI authorities: re@gistry/reponame",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "re@gistry/reponame"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Should pass with valid OCI repository name",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "gcr.io/google.com/project/hello-world"}},
 						},
 					},
 				},

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -636,6 +636,35 @@ func TestAuthoritiesValidation(t *testing.T) {
 			},
 		},
 		{
+			name:        "Should fail with invalid OCI value",
+			errorString: "invalid value: registry.example.com/repo/*: spec.authorities[0].source[0].oci\ncan only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "registry.example.com/repo/*"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Should pass with valid OCI repository name",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "registry.example.com/repository"}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:        "Should fail with invalid AWS KMS for Keyless",
 			errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].keyless.ca-cert.kms\nfailed to parse either key or alias arn: arn: not enough sections",
 			warnString:  "missing field(s): spec.authorities[0].keyless.identities",

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -30,13 +29,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 
+	registryfuncs "github.com/google/go-containerregistry/pkg/name"
+
 	policycontrollerconfig "github.com/sigstore/policy-controller/pkg/config"
 )
 
 const (
-	awsKMSPrefix       = "awskms://"
-	ociRepoDelimiter   = "/"
-	ociRepositoryChars = "abcdefghijklmnopqrstuvwxyz0123456789_-./"
+	awsKMSPrefix     = "awskms://"
+	ociRepoDelimiter = "/"
 )
 
 var (
@@ -225,34 +225,18 @@ func (source *Source) Validate(ctx context.Context) *apis.FieldError {
 	if source.OCI == "" {
 		errs = errs.Also(apis.ErrMissingField("oci"))
 	} else {
-		var registry string
-		repo := source.OCI
+		// We want to validate both registry uris only or registry with valid repository names
 		parts := strings.SplitN(source.OCI, ociRepoDelimiter, 2)
 		if len(parts) == 2 && (strings.ContainsRune(parts[0], '.') || strings.ContainsRune(parts[0], ':')) {
-			// The first part of the repository is treated as the registry domain
-			// iff it contains a '.' or ':' character, otherwise it is all repository.
-			registry = parts[0]
-			repo = parts[1]
-		}
-
-		// stripRunesFn returns a function which returns -1 (i.e. a value which
-		// signals deletion in strings.Map) for runes in 'runes', and the rune otherwise.
-		stripRunesFn := func(runes string) func(rune) rune {
-			return func(r rune) rune {
-				if strings.ContainsRune(runes, r) {
-					return -1
-				}
-				return r
+			_, err := registryfuncs.NewRepository(source.OCI, registryfuncs.StrictValidation)
+			if err != nil {
+				errs = errs.Also(apis.ErrInvalidValue(source.OCI, "oci", err.Error()))
 			}
-		}
-
-		// Check a given repository matches character restrictions if provided
-		if len(parts) > 1 && len(strings.Map(stripRunesFn(ociRepositoryChars), repo)) != 0 {
-			errs = errs.Also(apis.ErrInvalidValue(source.OCI, "oci", fmt.Sprintf("can only contain the characters `%s`", ociRepositoryChars)))
-		}
-		// Check a given registry is a valid RFC 3986 URI
-		if url, err := url.Parse("//" + registry); err != nil || url.Host != registry {
-			errs = errs.Also(apis.ErrInvalidValue(source.OCI, "oci", fmt.Sprintf("registries must be valid RFC 3986 URI authorities: %s", source.OCI)))
+		} else {
+			_, err := registryfuncs.NewRegistry(source.OCI, registryfuncs.StrictValidation)
+			if err != nil {
+				errs = errs.Also(apis.ErrInvalidValue(source.OCI, "oci", err.Error()))
+			}
 		}
 	}
 

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -32,7 +33,11 @@ import (
 	policycontrollerconfig "github.com/sigstore/policy-controller/pkg/config"
 )
 
-const awsKMSPrefix = "awskms://"
+const (
+	awsKMSPrefix       = "awskms://"
+	ociRepoDelimiter   = "/"
+	ociRepositoryChars = "abcdefghijklmnopqrstuvwxyz0123456789_-./"
+)
 
 var (
 	// TODO: create constants in to cosign?
@@ -219,6 +224,36 @@ func (source *Source) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 	if source.OCI == "" {
 		errs = errs.Also(apis.ErrMissingField("oci"))
+	} else {
+		var registry string
+		repo := source.OCI
+		parts := strings.SplitN(source.OCI, ociRepoDelimiter, 2)
+		if len(parts) == 2 && (strings.ContainsRune(parts[0], '.') || strings.ContainsRune(parts[0], ':')) {
+			// The first part of the repository is treated as the registry domain
+			// iff it contains a '.' or ':' character, otherwise it is all repository.
+			registry = parts[0]
+			repo = parts[1]
+		}
+
+		// stripRunesFn returns a function which returns -1 (i.e. a value which
+		// signals deletion in strings.Map) for runes in 'runes', and the rune otherwise.
+		stripRunesFn := func(runes string) func(rune) rune {
+			return func(r rune) rune {
+				if strings.ContainsRune(runes, r) {
+					return -1
+				}
+				return r
+			}
+		}
+
+		// Check a given repository matches character restrictions if provided
+		if len(parts) > 1 && len(strings.Map(stripRunesFn(ociRepositoryChars), repo)) != 0 {
+			errs = errs.Also(apis.ErrInvalidValue(source.OCI, "oci", fmt.Sprintf("can only contain the characters `%s`", ociRepositoryChars)))
+		}
+		// Check a given registry is a valid RFC 3986 URI
+		if url, err := url.Parse("//" + registry); err != nil || url.Host != registry {
+			errs = errs.Also(apis.ErrInvalidValue(source.OCI, "oci", fmt.Sprintf("registries must be valid RFC 3986 URI authorities: %s", source.OCI)))
+		}
 	}
 
 	if len(source.SignaturePullSecrets) > 0 {

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -178,6 +178,35 @@ func TestKeyValidation(t *testing.T) {
 			},
 		},
 		{
+			name:        "Should fail with invalid OCI value",
+			errorString: "invalid value: registry.example.com/repo/*: spec.authorities[0].source[0].oci\ncan only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "registry.example.com/repo/*"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Should pass with valid OCI repository name",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "registry.example.com/repository"}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Should pass when key has only one property: %v",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -179,7 +179,7 @@ func TestKeyValidation(t *testing.T) {
 		},
 		{
 			name:        "Should fail with invalid OCI value",
-			errorString: "invalid value: registry.example.com/repo/*: spec.authorities[0].source[0].oci\ncan only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`",
+			errorString: "invalid value: registry.example.com/repo/*: spec.authorities[0].source[0].oci\nrepository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: repo/*",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{{Glob: "gcr.io/*"}},
@@ -187,6 +187,35 @@ func TestKeyValidation(t *testing.T) {
 						{
 							Key:     &KeyRef{KMS: "kms://key/path"},
 							Sources: []Source{{OCI: "registry.example.com/repo/*"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Should fail with invalid OCI value usign wrong characters",
+			errorString: "invalid value: re@gistry/reponame: spec.authorities[0].source[0].oci\nregistries must be valid RFC 3986 URI authorities: re@gistry/reponame",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "re@gistry/reponame"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Should pass with valid OCI repository name",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "gcr.io/google.com/project/hello-world"}},
 						},
 					},
 				},


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Add a validation to avoid setting wrong values for the source.OCI.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Add a validation  to avoid setting wrong values for the source.OCI.
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->