### PR TITLE
Fix: switch from `all` to `ALL` when dropping capabilities.

### DIFF
--- a/config/policy-webhook.yaml
+++ b/config/policy-webhook.yaml
@@ -72,7 +72,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         volumeMounts:
         # Failing to provide a writable $HOME can cause TUF client initialization to panic

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -80,7 +80,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         volumeMounts:
         - name: homedir


### PR DESCRIPTION
:bug: TIL that `all` isn't recognized by K8s upstream, and they hardcode an `ALL` constant

ref: https://github.com/knative-sandbox/eventing-rabbitmq/pull/954#pullrequestreview-1153348371

/kind bug

#### Release Note

Change the way we drop capabilities from `all` to `ALL`, which is the constant K8s expects.

#### Documentation


cc @hectorj2f @vaikas 