### PR TITLE
Set no matching policy flag in the cache entry

### DIFF
--- a/pkg/webhook/cache.go
+++ b/pkg/webhook/cache.go
@@ -46,10 +46,11 @@ func ToContext(ctx context.Context, cache ResultCache) context.Context {
 
 type ResultCache interface {
 	// Set caches a PolicyResult for a given CIP evaluated for a given image at
-	// a particular point in time. image, uid & resourceVersion will give a
+	// a particular point in time. image, uid, name & resourceVersion will give a
 	// unique point in time, so we can make sure we're not caching things that
-	// are out of date.
-	Set(ctx context.Context, image, name, uid, resourceVersion string, cacheResult *CacheResult)
+	// are out of date. We need to cache any image that does not match any policy,
+	// thereby this function has a parameter noMatchingPolicy to specify it.
+	Set(ctx context.Context, image, name, uid, resourceVersion string, noMatchingPolicy bool, cacheResult *CacheResult)
 
 	// Get returns a cached result for a given image or nil if there are none.
 	Get(ctx context.Context, image, uid, resourceVersion string) *CacheResult

--- a/pkg/webhook/nocache.go
+++ b/pkg/webhook/nocache.go
@@ -27,5 +27,5 @@ func (nc *NoCache) Get(ctx context.Context, image, uid, resourceVersion string) 
 	return nil
 }
 
-func (nc *NoCache) Set(ctx context.Context, image, name, uid, resourceVersion string, cacheResult *CacheResult) {
+func (nc *NoCache) Set(ctx context.Context, image, name, uid, resourceVersion string, noMatchingPolicy bool, cacheResult *CacheResult) {
 }


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

We decided to cache the results when an image does not apply to any policy. To do so, we add a flag to the Set(...) function. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Add a flag `NoMatchingPolicy` to the cache entries.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->