### PR TITLE
Feature: Incorporate an identifier for signatures and attestations.

### DIFF
--- a/pkg/webhook/validator_result.go
+++ b/pkg/webhook/validator_result.go
@@ -55,6 +55,10 @@ type AuthorityMatch struct {
 // signature could be a signature on the Image (.sig) or on an Attestation
 // (.att).
 type PolicySignature struct {
+	// A unique identifier describing this signature.
+	// This is typically the hash of this signature's OCI layer for images.
+	ID string `json:"id,omitempty"`
+
 	// Subject that was found to match on the Cert.
 	Subject string `json:"subject,omitempty"`
 	// Issure that was found to match on the Cert.

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -1611,6 +1611,7 @@ func TestValidatePolicy(t *testing.T) {
 			AuthorityMatches: map[string]AuthorityMatch{
 				"authority-0": {
 					Signatures: []PolicySignature{{
+						ID: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						// TODO(mattmoor): Is there anything we should encode for key-based?
 					}},
 				}},
@@ -1637,6 +1638,7 @@ func TestValidatePolicy(t *testing.T) {
 			AuthorityMatches: map[string]AuthorityMatch{
 				"authority-0": {
 					Signatures: []PolicySignature{{
+						ID: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						// TODO(mattmoor): Is there anything we should encode for key-based?
 					}},
 				}},
@@ -1687,6 +1689,7 @@ func TestValidatePolicy(t *testing.T) {
 			AuthorityMatches: map[string]AuthorityMatch{
 				"authority-0": {
 					Signatures: []PolicySignature{{
+						ID: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						// TODO(mattmoor): Is there anything we should encode for key-based?
 					}},
 				}},
@@ -1713,6 +1716,7 @@ func TestValidatePolicy(t *testing.T) {
 					Attestations: map[string][]PolicyAttestation{
 						"test-att": {{
 							PolicySignature: PolicySignature{
+								ID:      "2b65cbf0e7901ba31d55b12d319bca39420af4388d3e5714d16f2019d74e3ab7",
 								Subject: "https://github.com/distroless/static/.github/workflows/release.yaml@refs/heads/main",
 								Issuer:  "https://token.actions.githubusercontent.com",
 								GithubExtensions: GithubExtensions{


### PR DESCRIPTION
:gift: This incorporates an identifier for signatures and attestations into a Policy Result, which should be suitable for identifying a signature or attestation across policy invocations (possibly across multiple policies).

/kind feature

#### Release Note

`PolicyResult` now includes an `Id` in `Policy{Signature,Attestation}` suitable for identifying the signature or attestation across contexts.

#### Documentation
