### PR TITLE
fix: allow spec.authorities field to not be specified

### DIFF
--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -55,6 +55,7 @@ type ClusterImagePolicySpec struct {
 	// Images defines the patterns of image names that should be subject to this policy.
 	Images []ImagePattern `json:"images"`
 	// Authorities defines the rules for discovering and validating signatures.
+	// +optional
 	Authorities []Authority `json:"authorities,omitempty"`
 	// Policy is an optional policy that can be applied against all the
 	// successfully validated Authorities. If no authorities pass, this does

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -55,7 +55,7 @@ type ClusterImagePolicySpec struct {
 	// Images defines the patterns of image names that should be subject to this policy.
 	Images []ImagePattern `json:"images"`
 	// Authorities defines the rules for discovering and validating signatures.
-	Authorities []Authority `json:"authorities"`
+	Authorities []Authority `json:"authorities,omitempty"`
 	// Policy is an optional policy that can be applied against all the
 	// successfully validated Authorities. If no authorities pass, this does
 	// not even get evaluated, as the Policy is considered failed.

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -55,6 +55,7 @@ type ClusterImagePolicySpec struct {
 	// Images defines the patterns of image names that should be subject to this policy.
 	Images []ImagePattern `json:"images"`
 	// Authorities defines the rules for discovering and validating signatures.
+	// +optional
 	Authorities []Authority `json:"authorities,omitempty"`
 	// Policy is an optional policy that can be applied against all the
 	// successfully validated Authorities. If no authorities pass, this does

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -55,7 +55,7 @@ type ClusterImagePolicySpec struct {
 	// Images defines the patterns of image names that should be subject to this policy.
 	Images []ImagePattern `json:"images"`
 	// Authorities defines the rules for discovering and validating signatures.
-	Authorities []Authority `json:"authorities"`
+	Authorities []Authority `json:"authorities,omitempty"`
 	// Policy is an optional policy that can be applied against all the
 	// successfully validated Authorities. If no authorities pass, this does
 	// not even get evaluated, as the Policy is considered failed.

--- a/test/e2e_test_policy_crd.sh
+++ b/test/e2e_test_policy_crd.sh
@@ -113,3 +113,35 @@ do
 done
 
 echo '::endgroup:: Valid policy test:'
+
+echo '::group:: Set fail-on-empty-authorities to false'
+kubectl patch configmap/config-policy-controller \
+  --namespace cosign-system \
+  --type merge \
+  --patch '{"data":{"no-match-policy":"deny", "fail-on-empty-authorities":"false"}}'
+# allow for propagation
+sleep 10
+echo '::endgroup::'
+
+echo '::group:: Empty authorities policies:'
+for i in `ls ./test/testdata/policy-controller/empty-authorities/`
+do
+  if kubectl create -f ./test/testdata/policy-controller/empty-authorities/$i ; then
+    echo "${i} created as expected"
+  else
+    echo "${i} failed when it should not have"
+    exit 1
+  fi
+
+  kubectl delete -f ./test/testdata/policy-controller/empty-authorities/$i --ignore-not-found=true
+done
+echo '::endgroup::'
+
+echo '::group:: Set fail-on-empty-authorities to true'
+kubectl patch configmap/config-policy-controller \
+  --namespace cosign-system \
+  --type merge \
+  --patch '{"data":{"no-match-policy":"deny", "fail-on-empty-authorities":"true"}}'
+# allow for propagation
+sleep 10
+echo '::endgroup::'

--- a/test/testdata/policy-controller/empty-authorities/authorities-absent.yaml
+++ b/test/testdata/policy-controller/empty-authorities/authorities-absent.yaml
@@ -1,0 +1,21 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy
+spec:
+  images:
+  - glob: image*

--- a/test/testdata/policy-controller/empty-authorities/authorities-present.yaml
+++ b/test/testdata/policy-controller/empty-authorities/authorities-present.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy
+spec:
+  images:
+  - glob: image*
+  authorities: []


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes #361 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Add `omitempty` to `authorities` to allow the `spec.authorities` field to not be specified.

This field being present and not nil is already conditionally validated (with the validation happening by default), so this should be safe to add.

To test the change:

1. Ensure `policy-controller` configuration includes `fail-on-empty-authorities: "false"`
2. Apply the following YAML:
```
apiVersion: policy.sigstore.dev/v1beta1
kind: ClusterImagePolicy
metadata:
  name: empty-authorities
spec:
  images:
  - glob: 'index.docker.io/*'
EOF
```

This should work, fails on latest main, but works with the code change from this PR.

#### Release Note

Allow `spec.authorities` field to not be specified

#### Documentation

N/A