### PR TITLE
Add FetchConfigFile to Policy that allows you to fetch and evaluate policy against container image configfile.

### DIFF
--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -103,6 +103,11 @@ jobs:
 
         # Wait for the webhook to come up and become Ready
         kubectl rollout status --timeout 5m --namespace cosign-system deployments/webhook
+        kubectl rollout status --timeout 5m --namespace cosign-system deployments/policy-webhook
+
+        # And make sure everything is up.
+        kubectl wait deployment -n cosign-system --for condition=Available=True --timeout=90s --all
+        sleep 10
 
     - name: Run Cluster Image Policy Tests
       timeout-minutes: 15

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -43,7 +43,7 @@ jobs:
         - cluster_with_scalable
         - cluster_image_policy_with_warn
         - cluster_image_policy_with_source
-        - cluster_image_policy_with_config_file
+        - cluster_image_policy_with_fetch_config_file
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
         - v1.23.x
@@ -42,6 +43,7 @@ jobs:
         - cluster_with_scalable
         - cluster_image_policy_with_warn
         - cluster_image_policy_with_source
+        - cluster_image_policy_with_config_file
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -159,7 +159,7 @@ func main() {
 		log.Fatalf("Image does not match any of the provided globs")
 	}
 
-	result, errs := webhook.ValidatePolicy(ctx, ns, ref, *cip, remoteOpts...)
+	result, errs := webhook.ValidatePolicy(ctx, ns, ref, *cip, authn.DefaultKeychain, remoteOpts...)
 	errStrings := []string{}
 	warningStrings := []string{}
 	for _, err := range errs {

--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -79,6 +79,9 @@ spec:
                                 data:
                                   description: Data contains the policy definition.
                                   type: string
+                                fetchConfigFile:
+                                  description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                                  type: boolean
                                 type:
                                   description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
                                   type: string
@@ -259,6 +262,9 @@ spec:
                     data:
                       description: Data contains the policy definition.
                       type: string
+                    fetchConfigFile:
+                      description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                      type: boolean
                     type:
                       description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
                       type: string
@@ -308,6 +314,9 @@ spec:
                                   type: string
                                 url:
                                   type: string
+                                fetchConfigFile:
+                                  description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                                  type: boolean
                             predicateType:
                               description: Which predicate type to verify. Matches cosign verify-attestation options.
                               type: string
@@ -464,6 +473,9 @@ spec:
                           type: string
                     data:
                       type: string
+                    fetchConfigFile:
+                      description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                      type: boolean
                     type:
                       description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
                       type: string

--- a/docs/api-types/index.md
+++ b/docs/api-types/index.md
@@ -156,7 +156,7 @@ MatchResource allows selecting resources based on its version, group and resourc
 
 ## Policy
 
-Policy specifies a policy to use for Attestation validation. Exactly one of Data, URL, or ConfigMapReference must be specified.
+Policy specifies a policy to use for Attestation or the CIP validation (iff at least one authority matches). Exactly one of Data, URL, or ConfigMapReference must be specified.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -164,6 +164,7 @@ Policy specifies a policy to use for Attestation validation. Exactly one of Data
 | data | Data contains the policy definition. | string | false |
 | url | URL to the policy data. | apis.URL | false |
 | configMapRef | ConfigMapRef defines the reference to a configMap with the policy definition. | [ConfigMapReference](#configmapreference) | false |
+| fetchConfigFile | FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 
 	"github.com/sigstore/policy-controller/pkg/apis/policy/v1beta1"
 )
@@ -183,6 +184,29 @@ func TestConversionRoundTripV1beta1(t *testing.T) {
 				Policy: &v1beta1.Policy{
 					Type: "cue",
 					Data: "cue language goes here",
+				},
+			},
+		},
+	}, {name: "key, keyless, and static, regexp, policy, fetchConfigFile",
+		in: &v1beta1.ClusterImagePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cip",
+			},
+			Spec: v1beta1.ClusterImagePolicySpec{
+				Images: []v1beta1.ImagePattern{{Glob: "*"}},
+				Authorities: []v1beta1.Authority{
+					{Key: &v1beta1.KeyRef{
+						SecretRef: &v1.SecretReference{Name: "mysecret"}}},
+					{Keyless: &v1beta1.KeylessRef{
+						Identities: []v1beta1.Identity{{SubjectRegExp: "subjectregexp", IssuerRegExp: "issuerregexp"}},
+						CACert:     &v1beta1.KeyRef{KMS: "kms", Data: "data", SecretRef: &v1.SecretReference{Name: "secret"}},
+					}},
+					{Static: &v1beta1.StaticRef{Action: "pass"}},
+				},
+				Policy: &v1beta1.Policy{
+					Type:            "cue",
+					Data:            "cue language goes here",
+					FetchConfigFile: ptr.Bool(true),
 				},
 			},
 		},

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -203,7 +203,8 @@ type MatchResource struct {
 	ResourceSelector *metav1.LabelSelector `json:"selector,omitempty"`
 }
 
-// Policy specifies a policy to use for Attestation validation.
+// Policy specifies a policy to use for Attestation or the CIP validation (iff
+// at least one authority matches).
 // Exactly one of Data, URL, or ConfigMapReference must be specified.
 type Policy struct {
 	// Which kind of policy this is, currently only rego or cue are supported.
@@ -218,6 +219,13 @@ type Policy struct {
 	// ConfigMapRef defines the reference to a configMap with the policy definition.
 	// +optional
 	ConfigMapRef *ConfigMapReference `json:"configMapRef,omitempty"`
+	// FetchConfigFile controls whether ConfigFile will be fetched and made
+	// available for CIP level policy evaluation. Note that this only gets
+	// evaluated (and hence fetched) iff at least one authority matches.
+	// The ConfigFile will then be available in this format:
+	// https://github.com/opencontainers/image-spec/blob/main/config.md
+	// +optional
+	FetchConfigFile *bool `json:"fetchConfigFile,omitempty"`
 }
 
 // ConfigMapReference is cut&paste from SecretReference, but for the life of me

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -78,7 +78,9 @@ func (spec *ClusterImagePolicySpec) Validate(ctx context.Context) (errors *apis.
 	for i, m := range spec.Match {
 		errors = errors.Also(m.Validate(ctx).ViaFieldIndex("match", i))
 	}
-	errors = errors.Also(spec.Policy.Validate(ctx))
+	// Note that we're within Spec here so that we can validate that the policy
+	// FetchConfigFile is only set within Spec.Policy.
+	errors = errors.Also(spec.Policy.Validate(apis.WithinSpec(ctx)))
 	return
 }
 
@@ -259,6 +261,9 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 	}
 	if p.Data == "" {
 		errs = errs.Also(apis.ErrMissingField("data"))
+	}
+	if !apis.IsInSpec(ctx) && p.FetchConfigFile != nil {
+		errs = errs.Also(apis.ErrDisallowedFields("fetchConfigFile"))
 	}
 	// TODO(vaikas): How to validate the cue / rego bytes here (data).
 	return errs

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
 )
 
 const validPublicKey = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaEOVJCFtduYr3xqTxeRWSW32CY/s\nTBNZj4oIUPl8JvhVPJ1TKDPlNcuT4YphSt6t3yOmMvkdQbCj8broX6vijw==\n-----END PUBLIC KEY-----"
@@ -403,6 +404,27 @@ func TestStaticValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "Works with pass, and Spec.Policy.FetchConfigFile",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "globbityglob",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Static: &StaticRef{Action: "pass"},
+						},
+					},
+					Policy: &Policy{
+						Type:            "cue",
+						Data:            `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
+						FetchConfigFile: ptr.Bool(true),
+					},
+				},
+			},
+		}, {
 			name: "Works with fail",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
@@ -775,6 +797,29 @@ func TestAuthoritiesValidation(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "Should fail with attestations policy specifying fetchConfigFile",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key: &KeyRef{KMS: "kms://key/path"},
+							Attestations: []Attestation{
+								{Name: "first", PredicateType: "vuln"},
+								{Name: "second", PredicateType: "custom", Policy: &Policy{
+									Type:            "cue",
+									Data:            `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
+									FetchConfigFile: ptr.Bool(true),
+								},
+								},
+							},
+						},
+					},
+				},
+			},
+			errorString: "must not set the field(s): spec.authorities[0].attestations.policy.fetchConfigFile",
 		},
 		{
 			name:        "Should fail with signaturePullSecret name empty",

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -332,6 +332,11 @@ func (in *Policy) DeepCopyInto(out *Policy) {
 		*out = new(ConfigMapReference)
 		**out = **in
 	}
+	if in.FetchConfigFile != nil {
+		in, out := &in.FetchConfigFile, &out.FetchConfigFile
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -193,7 +193,8 @@ type Attestation struct {
 	Policy *Policy `json:"policy,omitempty"`
 }
 
-// Policy specifies a policy to use for Attestation validation.
+// Policy specifies a policy to use for Attestation or the CIP validation (iff
+// at least one authority matches).
 // Exactly one of Data, URL, or ConfigMapReference must be specified.
 type Policy struct {
 	// Which kind of policy this is, currently only rego or cue are supported.
@@ -208,6 +209,13 @@ type Policy struct {
 	// ConfigMapRef defines the reference to a configMap with the policy definition.
 	// +optional
 	ConfigMapRef *ConfigMapReference `json:"configMapRef,omitempty"`
+	// FetchConfigFile controls whether ConfigFile will be fetched and made
+	// available for CIP level policy evaluation. Note that this only gets
+	// evaluated (and hence fetched) iff at least one authority matches.
+	// The ConfigFile will then be available in this format:
+	// https://github.com/opencontainers/image-spec/blob/main/config.md
+	// +optional
+	FetchConfigFile *bool `json:"fetchConfigFile,omitempty"`
 }
 
 // MatchResource allows selecting resources based on its version, group and resource.

--- a/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
@@ -332,6 +332,11 @@ func (in *Policy) DeepCopyInto(out *Policy) {
 		*out = new(ConfigMapReference)
 		**out = **in
 	}
+	if in.FetchConfigFile != nil {
+		in, out := &in.FetchConfigFile, &out.FetchConfigFile
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/webhook/validator_result.go
+++ b/pkg/webhook/validator_result.go
@@ -15,6 +15,10 @@
 
 package webhook
 
+import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
 // PolicyResult is the result of a successful ValidatePolicy call.
 // These are meant to be consumed by a higher level Policy engine that
 // can reason about validated results. The 'first' level pass will verify
@@ -33,6 +37,18 @@ type PolicyResult struct {
 	// AuthorityMatches will have an entry for each successful Authority check
 	// on it. Key in the map is the Attestation.Name
 	AuthorityMatches map[string]AuthorityMatch `json:"authorityMatches,omitempty"`
+
+	// Config contains the Config for each of the normalized os/architectures
+	// where key to the map is the {OS}/{Architecture}[/{Variant}]
+	//
+	// Some examples are:
+	// linux/arm64
+	// linux/arm/v7
+	// linux/arm/v6
+	//
+	// This field is only available for evaluation if
+	// CIP.Spec.Policy.FetchConfigFile is set to true.
+	Config map[string]*v1.ConfigFile `json:"config,omitempty"`
 }
 
 // AuthorityMatch returns either Signatures (if there are no Attestations

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -1726,7 +1726,11 @@ func TestValidatePolicy(t *testing.T) {
 			if test.customContext != nil {
 				testContext = test.customContext
 			}
-			got, gotErrs := ValidatePolicy(testContext, system.Namespace(), digest, test.policy)
+			kc, err := k8schain.NewNoClient(testContext)
+			if err != nil {
+				t.Fatalf("Failed to construct no client k8schain for testing")
+			}
+			got, gotErrs := ValidatePolicy(testContext, system.Namespace(), digest, test.policy, kc)
 			validateErrors(t, test.wantErrs, gotErrs)
 			if !reflect.DeepEqual(test.want, got) {
 				t.Errorf("unexpected PolicyResult, want: %+v got: %+v", test.want, got)
@@ -2592,9 +2596,14 @@ func TestValidatePolicyCancelled(t *testing.T) {
 			},
 		}},
 	}
+	kc, err := k8schain.NewNoClient(testContext)
+	if err != nil {
+		t.Fatalf("Failed to construct no client k8schain for testing")
+	}
+
 	wantErrs := []string{"context canceled before validation completed"}
 	cancelFunc()
-	_, gotErrs := ValidatePolicy(testContext, system.Namespace(), digest, cip)
+	_, gotErrs := ValidatePolicy(testContext, system.Namespace(), digest, cip, kc)
 	validateErrors(t, wantErrs, gotErrs)
 }
 
@@ -2621,9 +2630,13 @@ func TestValidatePoliciesCancelled(t *testing.T) {
 			},
 		}},
 	}
+	kc, err := k8schain.NewNoClient(testContext)
+	if err != nil {
+		t.Fatalf("Failed to construct no client k8schain for testing")
+	}
 	wantErrs := []string{"context was canceled before validation completed"}
 	cancelFunc()
-	_, gotErrs := validatePolicies(testContext, system.Namespace(), digest, map[string]webhookcip.ClusterImagePolicy{"testcip": cip})
+	_, gotErrs := validatePolicies(testContext, system.Namespace(), digest, map[string]webhookcip.ClusterImagePolicy{"testcip": cip}, kc)
 	validateErrors(t, wantErrs, gotErrs["internalerror"])
 }
 

--- a/test/e2e_test_cluster_image_policy_with_config_file.sh
+++ b/test/e2e_test_cluster_image_policy_with_config_file.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#set -ex
+set -e
+
+# This is a timestamp server that has multiarch that we just use for testing
+# evaluating CIP level policy validations.
+export demoimage="ghcr.io/sigstore/timestamp-server@sha256:dcf2f3a640bfb0a5d17aabafb34b407fe4403363c715718ab305a62b3606540d"
+
+# To simplify testing failures, use this function to execute a kubectl to create
+# our job and verify that the failure is expected.
+assert_error() {
+  local KUBECTL_OUT_FILE="/tmp/kubectl.failure.out"
+  match="$@"
+  echo looking for ${match}
+  kubectl delete job job-that-fails -n ${NS} --ignore-not-found=true
+  if kubectl create -n ${NS} job job-that-fails --image=${demoimage} 2> ${KUBECTL_OUT_FILE} ; then
+    echo Failed to block expected Job failure!
+    exit 1
+  else
+    echo Successfully blocked Job creation with expected error: "${match}"
+    if ! grep -q "${match}" ${KUBECTL_OUT_FILE} ; then
+      echo Did not get expected failure message, wanted "${match}", got
+      cat ${KUBECTL_OUT_FILE}
+      exit 1
+    fi
+  fi
+}
+
+echo '::group:: Create test namespace and label for verification'
+kubectl create namespace demo-config-file
+kubectl label namespace demo-config-file policy.sigstore.dev/include=true
+export NS=demo-config-file
+echo '::endgroup::'
+
+echo '::group:: Deploy ClusterImagePolicy with config file that should fail'
+kubectl apply -f ./test/testdata/policy-controller/e2e/cip-config-file-policy-fails.yaml
+# allow things to propagate
+sleep 5
+echo '::endgroup::'
+
+echo '::group:: validate failure '
+expected_error='failed evaluating cue policy for ClusterImagePolicy: failed to evaluate the policy with error: config."linux/amd64".config.User: conflicting values'
+assert_error ${expected_error}
+echo '::endgroup::'
+
+echo '::group:: Remove failingClusterImagePolicy and create one that passes'
+kubectl delete -f ./test/testdata/policy-controller/e2e/cip-config-file-policy-fails.yaml
+kubectl apply -f ./test/testdata/policy-controller/e2e/cip-config-file-policy.yaml
+# allow things to propagate
+sleep 5
+echo '::endgroup::'
+
+echo '::group:: test job success'
+# We signed this above, this should work
+if ! kubectl create -n ${NS} job demo --image=${demoimage} ; then
+  echo Failed to create Job in namespace with valid CIP policy!
+  exit 1
+else
+  echo Succcessfully created Job with signed image
+fi
+echo '::endgroup::'
+
+echo '::group::' Cleanup
+kubectl delete cip --all
+kubectl delete ns ${NS}
+echo '::endgroup::'
+

--- a/test/e2e_test_cluster_image_policy_with_fetch_config_file.sh
+++ b/test/e2e_test_cluster_image_policy_with_fetch_config_file.sh
@@ -67,7 +67,7 @@ sleep 5
 echo '::endgroup::'
 
 echo '::group:: test job success'
-# We signed this above, this should work
+# This one should pass since the User is what we specified in the CIP policy.
 if ! kubectl create -n ${NS} job demo --image=${demoimage} ; then
   echo Failed to create Job in namespace with valid CIP policy!
   exit 1

--- a/test/e2e_test_cluster_image_policy_with_fetch_config_file.sh
+++ b/test/e2e_test_cluster_image_policy_with_fetch_config_file.sh
@@ -48,8 +48,22 @@ kubectl label namespace demo-config-file policy.sigstore.dev/include=true
 export NS=demo-config-file
 echo '::endgroup::'
 
+# Note that we put this in a for loop to make sure the webhook is actually
+# up and running before proceeding with the tests.
 echo '::group:: Deploy ClusterImagePolicy with config file that should fail'
-kubectl apply -f ./test/testdata/policy-controller/e2e/cip-config-file-policy-fails.yaml
+for i in {1..10}
+do
+  if kubectl apply -f ./test/testdata/policy-controller/e2e/cip-config-file-policy-fails.yaml ; then
+    echo successfully applied failing CIP
+    break
+  fi
+  if [ "$i" == 10 ]; then
+    echo failed to apply failing CIP
+    exit 1
+  fi
+  echo failed to apply failing CIP. Attempt numer "$i", retrying
+  sleep 2
+done
 # allow things to propagate
 sleep 5
 echo '::endgroup::'

--- a/test/testdata/policy-controller/e2e/cip-config-file-policy-fails.yaml
+++ b/test/testdata/policy-controller/e2e/cip-config-file-policy-fails.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-config-file-fail
+spec:
+  images:
+  - glob: "ghcr.io/sigstore/timestamp-server**"
+  authorities:
+  - static:
+      action: pass
+  policy:
+    fetchConfigFile: true
+    type: "cue"
+    data: |
+      config: "linux/amd64": config: User: "55554"

--- a/test/testdata/policy-controller/e2e/cip-config-file-policy.yaml
+++ b/test/testdata/policy-controller/e2e/cip-config-file-policy.yaml
@@ -1,0 +1,30 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-config-file
+spec:
+  images:
+  - glob: "ghcr.io/sigstore/timestamp-server**"
+  authorities:
+  - static:
+      action: pass
+  policy:
+    fetchConfigFile: true
+    type: "cue"
+    data: |
+      config: "linux/amd64": config: User: "65532"
+      config: "linux/arm/v7": config: User: "65532"


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Addresses the configfile part of #385

Add flag to spec.policy `fetchConfigFile` that when set to true will fetch and make the ConfigFile available for CIP level
policy evalutions.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
 * Add FetchConfigFile into cip.Spec.Policy that allows one to fetch OCI config files (https://github.com/opencontainers/image-spec/blob/main/config.md) that are then available for evaluation in the cip.Spec.Policy
 
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->