### PR TITLE
fix: v1beta1 version converter that ignored the field spec.policy

### DIFF
--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
@@ -67,6 +67,12 @@ func (spec *ClusterImagePolicySpec) ConvertTo(ctx context.Context, sink *v1beta1
 		}
 		sink.Match = append(sink.Match, v1beta1Match)
 	}
+	if spec.Policy != nil {
+		sink.Policy = &v1beta1.Policy{
+			Type: spec.Policy.Type,
+			Data: spec.Policy.Data,
+		}
+	}
 	sink.Mode = spec.Mode
 	return nil
 }
@@ -164,6 +170,12 @@ func (spec *ClusterImagePolicySpec) ConvertFrom(ctx context.Context, source *v1b
 		spec.Match = append(spec.Match, matchResource)
 	}
 	spec.Mode = source.Mode
+	if source.Policy != nil {
+		spec.Policy = &Policy{
+			Type: source.Policy.Type,
+			Data: source.Policy.Data,
+		}
+	}
 	return nil
 }
 

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
@@ -164,6 +164,28 @@ func TestConversionRoundTripV1beta1(t *testing.T) {
 				},
 			},
 		},
+	}, {name: "key, keyless, and static, regexp, policy",
+		in: &v1beta1.ClusterImagePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cip",
+			},
+			Spec: v1beta1.ClusterImagePolicySpec{
+				Images: []v1beta1.ImagePattern{{Glob: "*"}},
+				Authorities: []v1beta1.Authority{
+					{Key: &v1beta1.KeyRef{
+						SecretRef: &v1.SecretReference{Name: "mysecret"}}},
+					{Keyless: &v1beta1.KeylessRef{
+						Identities: []v1beta1.Identity{{SubjectRegExp: "subjectregexp", IssuerRegExp: "issuerregexp"}},
+						CACert:     &v1beta1.KeyRef{KMS: "kms", Data: "data", SecretRef: &v1.SecretReference{Name: "secret"}},
+					}},
+					{Static: &v1beta1.StaticRef{Action: "pass"}},
+				},
+				Policy: &v1beta1.Policy{
+					Type: "cue",
+					Data: "cue language goes here",
+				},
+			},
+		},
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml
@@ -95,7 +95,6 @@ spec:
   policy:
     type: cue
     data: |
-      package sigstore
       import "struct"
       import "list"
       authorityMatches: {


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

While debugging a cue policy validation, I found that the spec.policy field was not been converted, and so no validation was done based on the cue data.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Fix: Policy converter was ignore spec.policy fields when converting v1beta1 policies.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->