### PR TITLE
Add includeObjectMetadata for including objectMeta in CIP policy eval.

### DIFF
--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -45,6 +45,7 @@ jobs:
         - cluster_image_policy_with_source
         - cluster_image_policy_with_fetch_config_file
         - cluster_image_policy_with_include_spec
+        - cluster_image_policy_with_include_objectmeta
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"

--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -82,6 +82,9 @@ spec:
                                 fetchConfigFile:
                                   description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
                                   type: boolean
+                                includeObjectMeta:
+                                  description: IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                                  type: boolean
                                 includeSpec:
                                   description: IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy.
                                   type: boolean
@@ -268,6 +271,9 @@ spec:
                     fetchConfigFile:
                       description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
                       type: boolean
+                    includeObjectMeta:
+                      description: IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                      type: boolean
                     includeSpec:
                       description: IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy.
                       type: boolean
@@ -322,6 +328,12 @@ spec:
                                   type: string
                                 fetchConfigFile:
                                   description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                                  type: boolean
+                                includeObjectMeta:
+                                  description: IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                                  type: boolean
+                                includeSpec:
+                                  description: IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy.
                                   type: boolean
                             predicateType:
                               description: Which predicate type to verify. Matches cosign verify-attestation options.
@@ -481,6 +493,12 @@ spec:
                       type: string
                     fetchConfigFile:
                       description: 'FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md'
+                      type: boolean
+                    includeObjectMeta:
+                      description: IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches.
+                      type: boolean
+                    includeSpec:
+                      description: IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy.
                       type: boolean
                     type:
                       description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)

--- a/docs/api-types/index.md
+++ b/docs/api-types/index.md
@@ -166,6 +166,7 @@ Policy specifies a policy to use for Attestation or the CIP validation (iff at l
 | configMapRef | ConfigMapRef defines the reference to a configMap with the policy definition. | [ConfigMapReference](#configmapreference) | false |
 | fetchConfigFile | FetchConfigFile controls whether ConfigFile will be fetched and made available for CIP level policy evaluation. Note that this only gets evaluated (and hence fetched) iff at least one authority matches. The ConfigFile will then be available in this format: https://github.com/opencontainers/image-spec/blob/main/config.md | bool | false |
 | includeSpec | IncludeSpec controls whether resource `Spec` will be included and made available for CIP level policy evaluation. Note that this only gets evaluated iff at least one authority matches. Also note that because Spec may be of a different shape depending on the resource being evaluatied (see MatchResource for filtering) you might want to configure these to match the policy file to ensure the shape of the Spec is what you expect when evaling the policy. | bool | false |
+| includeObjectMeta | IncludeObjectMeta controls whether the ObjectMeta will be included and made available for CIP level policy evalutation. Note that this only gets evaluated iff at least one authority matches. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
@@ -150,6 +150,9 @@ func (p *Policy) ConvertTo(ctx context.Context, sink *v1beta1.Policy) {
 	if p.IncludeSpec != nil {
 		sink.IncludeSpec = ptr.Bool(*p.IncludeSpec)
 	}
+	if p.IncludeObjectMeta != nil {
+		sink.IncludeObjectMeta = ptr.Bool(*p.IncludeObjectMeta)
+	}
 }
 
 func (p *Policy) ConvertFrom(ctx context.Context, source *v1beta1.Policy) {
@@ -169,6 +172,9 @@ func (p *Policy) ConvertFrom(ctx context.Context, source *v1beta1.Policy) {
 	}
 	if source.IncludeSpec != nil {
 		p.IncludeSpec = ptr.Bool(*source.IncludeSpec)
+	}
+	if source.IncludeObjectMeta != nil {
+		p.IncludeObjectMeta = ptr.Bool(*source.IncludeObjectMeta)
 	}
 }
 

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
@@ -211,6 +211,31 @@ func TestConversionRoundTripV1beta1(t *testing.T) {
 				},
 			},
 		},
+	}, {name: "key, keyless, and static, regexp, policy, fetchConfigFile, includeSpec, includeObjectMeta",
+		in: &v1beta1.ClusterImagePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cip",
+			},
+			Spec: v1beta1.ClusterImagePolicySpec{
+				Images: []v1beta1.ImagePattern{{Glob: "*"}},
+				Authorities: []v1beta1.Authority{
+					{Key: &v1beta1.KeyRef{
+						SecretRef: &v1.SecretReference{Name: "mysecret"}}},
+					{Keyless: &v1beta1.KeylessRef{
+						Identities: []v1beta1.Identity{{SubjectRegExp: "subjectregexp", IssuerRegExp: "issuerregexp"}},
+						CACert:     &v1beta1.KeyRef{KMS: "kms", Data: "data", SecretRef: &v1.SecretReference{Name: "secret"}},
+					}},
+					{Static: &v1beta1.StaticRef{Action: "pass"}},
+				},
+				Policy: &v1beta1.Policy{
+					Type:              "cue",
+					Data:              "cue language goes here",
+					FetchConfigFile:   ptr.Bool(true),
+					IncludeSpec:       ptr.Bool(true),
+					IncludeObjectMeta: ptr.Bool(true),
+				},
+			},
+		},
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -235,6 +235,11 @@ type Policy struct {
 	// the shape of the Spec is what you expect when evaling the policy.
 	// +optional
 	IncludeSpec *bool `json:"includeSpec,omitempty"`
+	// IncludeObjectMeta controls whether the ObjectMeta will be included and
+	// made available for CIP level policy evalutation. Note that this only gets
+	// evaluated iff at least one authority matches.
+	// +optional
+	IncludeObjectMeta *bool `json:"includeObjectMeta,omitempty"`
 }
 
 // ConfigMapReference is cut&paste from SecretReference, but for the life of me

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -268,6 +268,9 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 	if !apis.IsInSpec(ctx) && p.IncludeSpec != nil {
 		errs = errs.Also(apis.ErrDisallowedFields("includeSpec"))
 	}
+	if !apis.IsInSpec(ctx) && p.IncludeObjectMeta != nil {
+		errs = errs.Also(apis.ErrDisallowedFields("includeObjectMeta"))
+	}
 	// TODO(vaikas): How to validate the cue / rego bytes here (data).
 	return errs
 }

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -427,6 +427,27 @@ func TestStaticValidation(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Works with pass, and Spec.Policy.IncludeObjectMeta",
+		policy: ClusterImagePolicy{
+			Spec: ClusterImagePolicySpec{
+				Images: []ImagePattern{
+					{
+						Glob: "globbityglob",
+					},
+				},
+				Authorities: []Authority{
+					{
+						Static: &StaticRef{Action: "pass"},
+					},
+				},
+				Policy: &Policy{
+					Type:              "cue",
+					Data:              `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
+					IncludeObjectMeta: ptr.Bool(true),
+				},
+			},
+		},
+	}, {
 		name: "Works with fail",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
@@ -825,6 +846,28 @@ func TestAuthoritiesValidation(t *testing.T) {
 			},
 		},
 		errorString: "must not set the field(s): spec.authorities[0].attestations.policy.includeSpec",
+	}, {
+		name: "Should fail with attestations policy specifying includeObjectMeta",
+		policy: ClusterImagePolicy{
+			Spec: ClusterImagePolicySpec{
+				Images: []ImagePattern{{Glob: "gcr.io/*"}},
+				Authorities: []Authority{
+					{
+						Key: &KeyRef{KMS: "kms://key/path"},
+						Attestations: []Attestation{
+							{Name: "first", PredicateType: "vuln"},
+							{Name: "second", PredicateType: "custom", Policy: &Policy{
+								Type:              "cue",
+								Data:              `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
+								IncludeObjectMeta: ptr.Bool(true),
+							},
+							},
+						},
+					},
+				},
+			},
+		},
+		errorString: "must not set the field(s): spec.authorities[0].attestations.policy.includeObjectMeta",
 	}, {
 		name:        "Should fail with signaturePullSecret name empty",
 		errorString: "missing field(s): spec.authorities[0].source[0].signaturePullSecrets[0].name",

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -342,6 +342,11 @@ func (in *Policy) DeepCopyInto(out *Policy) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.IncludeObjectMeta != nil {
+		in, out := &in.IncludeObjectMeta, &out.IncludeObjectMeta
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -225,6 +225,11 @@ type Policy struct {
 	// the shape of the Spec is what you expect when evaling the policy.
 	// +optional
 	IncludeSpec *bool `json:"includeSpec,omitempty"`
+	// IncludeObjectMeta controls whether the ObjectMeta will be included and
+	// made available for CIP level policy evalutation. Note that this only gets
+	// evaluated iff at least one authority matches.
+	// +optional
+	IncludeObjectMeta *bool `json:"includeObjectMeta,omitempty"`
 }
 
 // MatchResource allows selecting resources based on its version, group and resource.

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -269,6 +269,9 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 	if !apis.IsInSpec(ctx) && p.IncludeSpec != nil {
 		errs = errs.Also(apis.ErrDisallowedFields("includeSpec"))
 	}
+	if !apis.IsInSpec(ctx) && p.IncludeObjectMeta != nil {
+		errs = errs.Also(apis.ErrDisallowedFields("includeObjectMeta"))
+	}
 	// TODO(vaikas): How to validate the cue / rego bytes here (data).
 	return errs
 }

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -475,6 +475,27 @@ func TestStaticValidation(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Works with pass, and Spec.Policy.IncludeObjectMeta",
+		policy: ClusterImagePolicy{
+			Spec: ClusterImagePolicySpec{
+				Images: []ImagePattern{
+					{
+						Glob: "globbityglob",
+					},
+				},
+				Authorities: []Authority{
+					{
+						Static: &StaticRef{Action: "pass"},
+					},
+				},
+				Policy: &Policy{
+					Type:              "cue",
+					Data:              `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
+					IncludeObjectMeta: ptr.Bool(true),
+				},
+			},
+		},
+	}, {
 		name: "Works with fail",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
@@ -805,6 +826,28 @@ func TestAuthoritiesValidation(t *testing.T) {
 			},
 		},
 		errorString: "must not set the field(s): spec.authorities[0].attestations.policy.includeSpec",
+	}, {
+		name: "Should fail with attestations policy specifying includeObjectMeta",
+		policy: ClusterImagePolicy{
+			Spec: ClusterImagePolicySpec{
+				Images: []ImagePattern{{Glob: "gcr.io/*"}},
+				Authorities: []Authority{
+					{
+						Key: &KeyRef{KMS: "kms://key/path"},
+						Attestations: []Attestation{
+							{Name: "first", PredicateType: "vuln"},
+							{Name: "second", PredicateType: "custom", Policy: &Policy{
+								Type:              "cue",
+								Data:              `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
+								IncludeObjectMeta: ptr.Bool(true),
+							},
+							},
+						},
+					},
+				},
+			},
+		},
+		errorString: "must not set the field(s): spec.authorities[0].attestations.policy.includeObjectMeta",
 	}, {
 		name:        "Should fail with signaturePullSecret name empty",
 		errorString: "missing field(s): spec.authorities[0].source[0].signaturePullSecrets[0].name",

--- a/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
@@ -342,6 +342,11 @@ func (in *Policy) DeepCopyInto(out *Policy) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.IncludeObjectMeta != nil {
+		in, out := &in.IncludeObjectMeta, &out.IncludeObjectMeta
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/webhook/clusterimagepolicy/clusterimagepolicy_types.go
+++ b/pkg/webhook/clusterimagepolicy/clusterimagepolicy_types.go
@@ -137,6 +137,11 @@ type AttestationPolicy struct {
 	// made available for CIP level policy evaluation. Note that this only gets
 	// evaluated iff at least one authority matches.
 	IncludeSpec *bool `json:"includeSpec,omitempty"`
+	// IncludeObjectMeta controls whether the ObjectMeta will be included and
+	// made available for CIP level policy evalutation. Note that this only gets
+	// evaluated iff at least one authority matches.
+	// +optional
+	IncludeObjectMeta *bool `json:"includeObjectMeta,omitempty"`
 }
 
 // UnmarshalJSON populates the PublicKeys using Data because
@@ -257,6 +262,9 @@ func ConvertClusterImagePolicyV1alpha1ToWebhook(in *v1alpha1.ClusterImagePolicy)
 		if in.Spec.Policy.IncludeSpec != nil {
 			cipAttestationPolicy.IncludeSpec = ptr.Bool(*in.Spec.Policy.IncludeSpec)
 		}
+		if in.Spec.Policy.IncludeObjectMeta != nil {
+			cipAttestationPolicy.IncludeObjectMeta = ptr.Bool(*in.Spec.Policy.IncludeObjectMeta)
+		}
 	}
 	return &ClusterImagePolicy{
 		UID:             copyIn.UID,
@@ -301,6 +309,9 @@ func convertAttestationsV1Alpha1ToWebhook(in []v1alpha1.Attestation) []Attestati
 			}
 			if inAtt.Policy.IncludeSpec != nil {
 				outAtt.IncludeSpec = ptr.Bool(*inAtt.Policy.IncludeSpec)
+			}
+			if inAtt.Policy.IncludeObjectMeta != nil {
+				outAtt.IncludeObjectMeta = ptr.Bool(*inAtt.Policy.IncludeObjectMeta)
 			}
 		}
 		ret = append(ret, outAtt)

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -151,8 +151,8 @@ func (v *Validator) ValidatePodSpecable(ctx context.Context, wp *duckv1.WithPod)
 		return nil
 	}
 
-	// Attach the spec for down the line to be attached if it's required by
-	// policy to be included in the PolicyResult.
+	// Attach the spec/objectMeta for down the line to be attached if it's
+	// required by policy to be included in the PolicyResult.
 	ctx = includeSpec(ctx, wp.Spec)
 	ctx = includeObjectMeta(ctx, wp.ObjectMeta)
 
@@ -176,8 +176,8 @@ func (v *Validator) ValidatePod(ctx context.Context, p *duckv1.Pod) *apis.FieldE
 		return nil
 	}
 
-	// Attach the spec for down the line to be attached if it's required by
-	// policy to be included in the PolicyResult.
+	// Attach the spec/objectMeta for down the line to be attached if it's
+	// required by policy to be included in the PolicyResult.
 	ctx = includeSpec(ctx, p.Spec)
 	ctx = includeObjectMeta(ctx, p.ObjectMeta)
 
@@ -201,8 +201,8 @@ func (v *Validator) ValidateCronJob(ctx context.Context, c *duckv1.CronJob) *api
 		return nil
 	}
 
-	// Attach the spec for down the line to be attached if it's required by
-	// policy to be included in the PolicyResult.
+	// Attach the spec/objectMeta for down the line to be attached if it's
+	// required by policy to be included in the PolicyResult.
 	ctx = includeSpec(ctx, c.Spec)
 	ctx = includeObjectMeta(ctx, c.ObjectMeta)
 

--- a/pkg/webhook/validator_result.go
+++ b/pkg/webhook/validator_result.go
@@ -57,6 +57,12 @@ type PolicyResult struct {
 	// This field is only available for evaluation if
 	// CIP.Spec.Policy.IncludeSpec is set to true.
 	Spec interface{} `json:"spec,omitempty"`
+
+	// ObjectMeta contains the ObjectMeta for the resource that was evaluated.
+	//
+	// This field is only available for evaluation if
+	// CIP.Spec.Policy.IncludeObjectMeta is set to true.
+	ObjectMeta interface{} `json:"objectMeta,omitempty"`
 }
 
 // AuthorityMatch returns either Signatures (if there are no Attestations

--- a/test/e2e_test_cluster_image_policy_with_include_objectmeta.sh
+++ b/test/e2e_test_cluster_image_policy_with_include_objectmeta.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#set -ex
+set -e
+
+# This is a timestamp server that we just use for testing evaluating CIP level
+# policy validations.
+export demoimage="ghcr.io/sigstore/timestamp-server@sha256:dcf2f3a640bfb0a5d17aabafb34b407fe4403363c715718ab305a62b3606540d"
+
+# To simplify testing failures, use this function to execute a kubectl to create
+# our pod and verify that the failure is expected. Note that this sets a label
+# that we expect to fail
+assert_error() {
+  local KUBECTL_OUT_FILE="/tmp/kubectl.failure.out"
+  match="$@"
+  echo looking for ${match}
+  kubectl delete pod pod-that-fails -n ${NS} --ignore-not-found=true
+  if kubectl run -n ${NS} -l="foo=bar" pod-that-fails --image=${demoimage} 2> ${KUBECTL_OUT_FILE} ; then
+    echo Failed to block expected Pod failure!
+    exit 1
+  else
+    echo Successfully blocked Pod creation with expected error: "${match}"
+    if ! grep -q "${match}" ${KUBECTL_OUT_FILE} ; then
+      echo Did not get expected failure message, wanted "${match}", got
+      cat ${KUBECTL_OUT_FILE}
+      exit 1
+    fi
+  fi
+}
+
+echo '::group:: Create test namespace and label for verification'
+kubectl create namespace demo-include-objectmeta
+kubectl label namespace demo-include-objectmeta policy.sigstore.dev/include=true
+export NS=demo-include-objectmeta
+echo '::endgroup::'
+
+# Note that we put this in a for loop to make sure the webhook is actually
+# up and running before proceeding with the tests.
+echo '::group:: Deploy ClusterImagePolicy with label that should fail'
+for i in {1..10}
+do
+  if kubectl apply -f ./test/testdata/policy-controller/e2e/cip-include-objectmeta-fails.yaml ; then
+    echo successfully applied failing CIP
+    break
+  fi
+  if [ "$i" == 10 ]; then
+    echo failed to apply failing CIP
+    exit 1
+  fi
+  echo failed to apply failing CIP. Attempt numer "$i", retrying
+  sleep 2
+done
+# allow things to propagate
+sleep 5
+echo '::endgroup::'
+
+echo '::group:: validate failure '
+expected_error='failed evaluating cue policy for ClusterImagePolicy: failed to evaluate the policy with error: objectMeta.labels.foo: conflicting values "bar" and "non-bar"'
+assert_error ${expected_error}
+echo '::endgroup::'
+
+echo '::group:: Remove failing ClusterImagePolicy and create one that passes'
+kubectl delete -f ./test/testdata/policy-controller/e2e/cip-include-objectmeta-fails.yaml
+kubectl apply -f ./test/testdata/policy-controller/e2e/cip-include-objectmeta.yaml
+# allow things to propagate
+sleep 5
+echo '::endgroup::'
+
+echo '::group:: test job success'
+# This one should pass since the label is what we specified in the CIP
+# policy.
+if ! kubectl run -n ${NS} -l="foo=bar" demo --image=${demoimage} ; then
+  echo Failed to create Pod in namespace with valid CIP policy!
+  exit 1
+else
+  echo Succcessfully created Pod with correct labels
+fi
+echo '::endgroup::'
+
+echo '::group::' Cleanup
+kubectl delete cip --all
+kubectl delete ns ${NS}
+echo '::endgroup::'
+

--- a/test/testdata/policy-controller/e2e/cip-include-objectmeta-fails.yaml
+++ b/test/testdata/policy-controller/e2e/cip-include-objectmeta-fails.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-objectmeta-fail
+spec:
+  images:
+  - glob: "ghcr.io/sigstore/timestamp-server**"
+  authorities:
+  - static:
+      action: pass
+  policy:
+    includeObjectMeta: true
+    type: "cue"
+    data: |
+      objectMeta: "labels": "foo": "non-bar"

--- a/test/testdata/policy-controller/e2e/cip-include-objectmeta.yaml
+++ b/test/testdata/policy-controller/e2e/cip-include-objectmeta.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-objectmeta
+spec:
+  images:
+  - glob: "ghcr.io/sigstore/timestamp-server**"
+  authorities:
+  - static:
+      action: pass
+  policy:
+    includeObjectMeta: true
+    type: "cue"
+    data: |
+      objectMeta: "labels": "foo": "bar"


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Continuation of #406 in a way, add includeObjectMeta into spec.policy which when set to true will include the resources ObjectMeta (things like labels/annotations) in the PolicyResult that then in turn are available in evaluating with CIP.Policy iff at least one authority matches.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
 * Continuation of #406 in a way, add includeObjectMeta into spec.policy which when set to true will include the resources ObjectMeta (things like labels/annotations) in the PolicyResult that then in turn are available in evaluating with CIP.Policy iff at least one authority matches.

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->