### PR TITLE
Cleanup: Rename `objectMeta` to `metadata` to align with K8s shape.

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -151,7 +151,7 @@ func (v *Validator) ValidatePodSpecable(ctx context.Context, wp *duckv1.WithPod)
 		return nil
 	}
 
-	// Attach the spec/objectMeta for down the line to be attached if it's
+	// Attach the spec/metadata for down the line to be attached if it's
 	// required by policy to be included in the PolicyResult.
 	ctx = includeSpec(ctx, wp.Spec)
 	ctx = includeObjectMeta(ctx, wp.ObjectMeta)
@@ -176,7 +176,7 @@ func (v *Validator) ValidatePod(ctx context.Context, p *duckv1.Pod) *apis.FieldE
 		return nil
 	}
 
-	// Attach the spec/objectMeta for down the line to be attached if it's
+	// Attach the spec/metadata for down the line to be attached if it's
 	// required by policy to be included in the PolicyResult.
 	ctx = includeSpec(ctx, p.Spec)
 	ctx = includeObjectMeta(ctx, p.ObjectMeta)
@@ -201,7 +201,7 @@ func (v *Validator) ValidateCronJob(ctx context.Context, c *duckv1.CronJob) *api
 		return nil
 	}
 
-	// Attach the spec/objectMeta for down the line to be attached if it's
+	// Attach the spec/metadata for down the line to be attached if it's
 	// required by policy to be included in the PolicyResult.
 	ctx = includeSpec(ctx, c.Spec)
 	ctx = includeObjectMeta(ctx, c.ObjectMeta)

--- a/pkg/webhook/validator_result.go
+++ b/pkg/webhook/validator_result.go
@@ -62,7 +62,7 @@ type PolicyResult struct {
 	//
 	// This field is only available for evaluation if
 	// CIP.Spec.Policy.IncludeObjectMeta is set to true.
-	ObjectMeta interface{} `json:"objectMeta,omitempty"`
+	ObjectMeta interface{} `json:"metadata,omitempty"`
 }
 
 // AuthorityMatch returns either Signatures (if there are no Attestations

--- a/test/e2e_test_cluster_image_policy_with_include_objectmeta.sh
+++ b/test/e2e_test_cluster_image_policy_with_include_objectmeta.sh
@@ -70,7 +70,7 @@ sleep 5
 echo '::endgroup::'
 
 echo '::group:: validate failure '
-expected_error='failed evaluating cue policy for ClusterImagePolicy: failed to evaluate the policy with error: objectMeta.labels.foo: conflicting values "bar" and "non-bar"'
+expected_error='failed evaluating cue policy for ClusterImagePolicy: failed to evaluate the policy with error: metadata.labels.foo: conflicting values "bar" and "non-bar"'
 assert_error ${expected_error}
 echo '::endgroup::'
 

--- a/test/testdata/policy-controller/e2e/cip-include-objectmeta-fails.yaml
+++ b/test/testdata/policy-controller/e2e/cip-include-objectmeta-fails.yaml
@@ -26,4 +26,6 @@ spec:
     includeObjectMeta: true
     type: "cue"
     data: |
-      objectMeta: "labels": "foo": "non-bar"
+      metadata:
+        labels:
+          foo: "non-bar"

--- a/test/testdata/policy-controller/e2e/cip-include-objectmeta.yaml
+++ b/test/testdata/policy-controller/e2e/cip-include-objectmeta.yaml
@@ -26,4 +26,6 @@ spec:
     includeObjectMeta: true
     type: "cue"
     data: |
-      objectMeta: "labels": "foo": "bar"
+      metadata:
+        labels:
+          foo: "bar"


### PR DESCRIPTION
:broom: This renamed `objectMeta:` to `metadata:` in `PolicyResult` so that the shape of what folks write for validation aligns with the shape of Kubernetes resources.

/kind cleanup

#### Release Note

🚨  THIS IS A BREAKING CHANGE 🚨, but talking to @vaikas we wanted to rip off the band-aid now before the field has meaningful adoption and cut a 0.5.1.

With this, folks can now write policies with the shape:

```yaml
metadata:
  annotations:
    foo: "bar"
spec:
  containers:
  - name: "baz"
```
