### PR TITLE
expose webhook validator getters

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -81,15 +81,15 @@ type includeSpecKey struct{}
 // levels and we want the highest resource level to be available, otherwise
 // everything boils down to PodSpec and it's lossy then.
 func IncludeSpec(ctx context.Context, spec interface{}) context.Context {
-	if getIncludeSpec(ctx) == nil {
+	if GetIncludeSpec(ctx) == nil {
 		return context.WithValue(ctx, includeSpecKey{}, spec)
 	}
 	return ctx
 }
 
-// getIncludeSpec returns the highest level spec for a resource possible.
+// GetIncludeSpec returns the highest level spec for a resource possible.
 // For example, for Deployment it would return Deployment.Spec
-func getIncludeSpec(ctx context.Context) interface{} {
+func GetIncludeSpec(ctx context.Context) interface{} {
 	return ctx.Value(includeSpecKey{})
 }
 
@@ -107,15 +107,15 @@ type includeTypeMetaKey struct{}
 // levels and we want the highest resource level to be available, otherwise
 // everything boils down to PodSpec and it's lossy then.
 func IncludeObjectMeta(ctx context.Context, meta interface{}) context.Context {
-	if getIncludeObjectMeta(ctx) == nil {
+	if GetIncludeObjectMeta(ctx) == nil {
 		return context.WithValue(ctx, includeObjectMetaKey{}, meta)
 	}
 	return ctx
 }
 
-// getIncludeObjectMeta returns the highest level ObjectMeta for a resource
+// GetIncludeObjectMeta returns the highest level ObjectMeta for a resource
 // possible. For example, for Deployment it would return Deployment.Spec
-func getIncludeObjectMeta(ctx context.Context) interface{} {
+func GetIncludeObjectMeta(ctx context.Context) interface{} {
 	return ctx.Value(includeObjectMetaKey{})
 }
 
@@ -125,17 +125,17 @@ func getIncludeObjectMeta(ctx context.Context) interface{} {
 // levels and we want the highest resource level to be available, otherwise
 // everything boils down to PodSpec and it's lossy then.
 func IncludeTypeMeta(ctx context.Context, meta interface{}) context.Context {
-	if getIncludeTypeMeta(ctx) == nil {
+	if GetIncludeTypeMeta(ctx) == nil {
 		return context.WithValue(ctx, includeTypeMetaKey{}, meta)
 	}
 	return ctx
 }
 
-// getIncludeTypeMeta returns the highest level TypeMeta for a resource
+// GetIncludeTypeMeta returns the highest level TypeMeta for a resource
 // possible. For example, for Deployment it would return:
 // apiVersion: apps/v1
 // kind: Deployment
-func getIncludeTypeMeta(ctx context.Context) interface{} {
+func GetIncludeTypeMeta(ctx context.Context) interface{} {
 	return ctx.Value(includeTypeMetaKey{})
 }
 
@@ -610,13 +610,13 @@ func ValidatePolicy(ctx context.Context, namespace string, ref name.Reference, c
 			policyResult.Config = configFiles
 		}
 		if cip.Policy.IncludeSpec != nil && *cip.Policy.IncludeSpec {
-			policyResult.Spec = getIncludeSpec(ctx)
+			policyResult.Spec = GetIncludeSpec(ctx)
 		}
 		if cip.Policy.IncludeObjectMeta != nil && *cip.Policy.IncludeObjectMeta {
-			policyResult.ObjectMeta = getIncludeObjectMeta(ctx)
+			policyResult.ObjectMeta = GetIncludeObjectMeta(ctx)
 		}
 		if cip.Policy.IncludeTypeMeta != nil && *cip.Policy.IncludeTypeMeta {
-			policyResult.TypeMeta = getIncludeTypeMeta(ctx)
+			policyResult.TypeMeta = GetIncludeTypeMeta(ctx)
 		}
 
 		logging.FromContext(ctx).Info("Validating CIP level policy")


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR exposes the webhook validator Getters for downstream consumers:

- `GetIncludeTypeMeta`
- `GetIncludeObjectMeta`
- `GetIncludeSpec`

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->