### PR TITLE
Add support for policy.configMapRef in attestation / cip.spec

### DIFF
--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -48,6 +48,7 @@ jobs:
         - cluster_image_policy_with_include_objectmeta
         - cluster_image_policy_with_attestations_rego
         - cluster_image_policy_with_include_typemeta
+        - cluster_image_policy_from_configmap_with_fetch_config_file
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"

--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -70,6 +70,9 @@ spec:
                                   description: ConfigMapRef defines the reference to a configMap with the policy definition.
                                   type: object
                                   properties:
+                                    key:
+                                      description: Key defines the key to pull from the configmap.
+                                      type: string
                                     name:
                                       description: Name is unique within a namespace to reference a configmap resource.
                                       type: string
@@ -268,6 +271,9 @@ spec:
                       description: ConfigMapRef defines the reference to a configMap with the policy definition.
                       type: object
                       properties:
+                        key:
+                          description: Key defines the key to pull from the configmap.
+                          type: string
                         name:
                           description: Name is unique within a namespace to reference a configmap resource.
                           type: string
@@ -329,6 +335,9 @@ spec:
                                   description: ConfigMapRef defines the reference to a configMap with the policy definition.
                                   type: object
                                   properties:
+                                    key:
+                                      description: Key defines the key to pull from the configmap.
+                                      type: string
                                     name:
                                       description: Name is unique within a namespace to reference a configmap resource.
                                       type: string
@@ -527,6 +536,9 @@ spec:
                       description: ConfigMapRef defines the reference to a configMap with the policy definition.
                       type: object
                       properties:
+                        key:
+                          description: Key defines the key to pull from the configmap.
+                          type: string
                         name:
                           description: Name is unique within a namespace to reference a configmap resource.
                           type: string

--- a/docs/api-types/index-v1alpha1.md
+++ b/docs/api-types/index-v1alpha1.md
@@ -207,6 +207,7 @@ ConfigMapReference is cut&paste from SecretReference, but for the life of me cou
 | ----- | ----------- | ------ | -------- |
 | name | Name is unique within a namespace to reference a configmap resource. | string | false |
 | namespace | Namespace defines the space within which the configmap name must be unique. | string | false |
+| key | Key defines the key to pull from the configmap. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/api-types/index.md
+++ b/docs/api-types/index.md
@@ -93,6 +93,7 @@ ConfigMapReference is cut&paste from SecretReference, but for the life of me cou
 | ----- | ----------- | ------ | -------- |
 | name | Name is unique within a namespace to reference a configmap resource. | string | false |
 | namespace | Namespace defines the space within which the configmap name must be unique. | string | false |
+| key | Key defines the key to pull from the configmap. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
@@ -146,6 +146,7 @@ func (p *Policy) ConvertTo(ctx context.Context, sink *v1beta1.Policy) {
 		sink.ConfigMapRef = &v1beta1.ConfigMapReference{
 			Name:      p.ConfigMapRef.Name,
 			Namespace: p.ConfigMapRef.Namespace,
+			Key:       p.ConfigMapRef.Key,
 		}
 	}
 	if p.FetchConfigFile != nil {
@@ -172,6 +173,7 @@ func (p *Policy) ConvertFrom(ctx context.Context, source *v1beta1.Policy) {
 		p.ConfigMapRef = &ConfigMapReference{
 			Name:      source.ConfigMapRef.Name,
 			Namespace: source.ConfigMapRef.Namespace,
+			Key:       source.ConfigMapRef.Key,
 		}
 	}
 	if source.FetchConfigFile != nil {

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
@@ -211,6 +211,41 @@ func TestConversionRoundTripV1beta1(t *testing.T) {
 				},
 			},
 		},
+	}, {name: "key, keyless, and static, regexp, policy with cmref, fetchConfigFile, includeSpec",
+		in: &v1beta1.ClusterImagePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cip",
+			},
+			Spec: v1beta1.ClusterImagePolicySpec{
+				Images: []v1beta1.ImagePattern{{Glob: "*"}},
+				Authorities: []v1beta1.Authority{
+					{Key: &v1beta1.KeyRef{
+						SecretRef: &v1.SecretReference{Name: "mysecret"}},
+						Attestations: []v1beta1.Attestation{{Policy: &v1beta1.Policy{
+							Type: "rego",
+							ConfigMapRef: &v1beta1.ConfigMapReference{
+								Name: "cip-cmname",
+								Key:  "cip-keyname",
+							},
+						},
+						}}},
+					{Keyless: &v1beta1.KeylessRef{
+						Identities: []v1beta1.Identity{{SubjectRegExp: "subjectregexp", IssuerRegExp: "issuerregexp"}},
+						CACert:     &v1beta1.KeyRef{KMS: "kms", Data: "data", SecretRef: &v1.SecretReference{Name: "secret"}},
+					}},
+					{Static: &v1beta1.StaticRef{Action: "pass"}},
+				},
+				Policy: &v1beta1.Policy{
+					Type: "cue",
+					ConfigMapRef: &v1beta1.ConfigMapReference{
+						Name: "cmname",
+						Key:  "keyname",
+					},
+					FetchConfigFile: ptr.Bool(true),
+					IncludeSpec:     ptr.Bool(true),
+				},
+			},
+		},
 	}, {name: "key, keyless, and static, regexp, policy, fetchConfigFile, includeSpec, includeObjectMeta, includeTypeMeta",
 		in: &v1beta1.ClusterImagePolicy{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -262,6 +262,9 @@ type ConfigMapReference struct {
 	// Namespace defines the space within which the configmap name must be unique.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+	// Key defines the key to pull from the configmap.
+	// +optional
+	Key string `json:"key,omitempty"`
 }
 
 // Identity may contain the issuer and/or the subject found in the transparency

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -251,6 +251,17 @@ func (a *Attestation) Validate(ctx context.Context) *apis.FieldError {
 	return errs
 }
 
+func (cmr *ConfigMapReference) Validate(ctx context.Context) *apis.FieldError {
+	var errs *apis.FieldError
+	if cmr.Name == "" {
+		errs = errs.Also(apis.ErrMissingField("name"))
+	}
+	if cmr.Key == "" {
+		errs = errs.Also(apis.ErrMissingField("key"))
+	}
+	return errs
+}
+
 func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 	if p == nil {
 		return nil
@@ -264,6 +275,9 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 	}
 	if p.Data != "" && p.ConfigMapRef != nil {
 		errs = errs.Also(apis.ErrMultipleOneOf("data", "configMapRef"))
+	}
+	if p.ConfigMapRef != nil {
+		errs = errs.Also(p.ConfigMapRef.Validate(ctx).ViaField("configMapRef"))
 	}
 	if !apis.IsInSpec(ctx) && p.FetchConfigFile != nil {
 		errs = errs.Also(apis.ErrDisallowedFields("fetchConfigFile"))

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -259,8 +259,11 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 	if p.Type != "cue" && p.Type != "rego" {
 		errs = errs.Also(apis.ErrInvalidValue(p.Type, "type", "only [cue,rego] are supported at the moment"))
 	}
-	if p.Data == "" {
-		errs = errs.Also(apis.ErrMissingField("data"))
+	if p.Data == "" && p.ConfigMapRef == nil {
+		errs = errs.Also(apis.ErrMissingField("data", "configMapRef"))
+	}
+	if p.Data != "" && p.ConfigMapRef != nil {
+		errs = errs.Also(apis.ErrMultipleOneOf("data", "configMapRef"))
 	}
 	if !apis.IsInSpec(ctx) && p.FetchConfigFile != nil {
 		errs = errs.Also(apis.ErrDisallowedFields("fetchConfigFile"))

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -992,13 +992,25 @@ func TestAttestationsValidation(t *testing.T) {
 		},
 		errorString: "invalid value: not-cue: policy.type\nonly [cue,rego] are supported at the moment",
 	}, {
-		name: "custom with missing policy data",
+		name: "custom with missing policy data and configMapRef",
 		attestation: Attestation{Name: "second", PredicateType: "custom",
 			Policy: &Policy{
 				Type: "cue",
 			},
 		},
-		errorString: "missing field(s): policy.data",
+		errorString: "missing field(s): policy.configMapRef, policy.data",
+	}, {
+		name: "custom with both policy data and configMapRef",
+		attestation: Attestation{Name: "second", PredicateType: "custom",
+			Policy: &Policy{
+				Type: "cue",
+				Data: `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
+				ConfigMapRef: &ConfigMapReference{
+					Name: "cmname",
+				},
+			},
+		},
+		errorString: "expected exactly one, got both: policy.configMapRef, policy.data",
 	}, {
 		name: "custom with policy",
 		attestation: Attestation{Name: "second", PredicateType: "custom",

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -1007,10 +1007,22 @@ func TestAttestationsValidation(t *testing.T) {
 				Data: `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
 				ConfigMapRef: &ConfigMapReference{
 					Name: "cmname",
+					Key:  "keyname",
 				},
 			},
 		},
 		errorString: "expected exactly one, got both: policy.configMapRef, policy.data",
+	}, {
+		name: "custom with invalid configMapRef, missing key",
+		attestation: Attestation{Name: "second", PredicateType: "custom",
+			Policy: &Policy{
+				Type: "cue",
+				ConfigMapRef: &ConfigMapReference{
+					Name: "cmname",
+				},
+			},
+		},
+		errorString: "missing field(s): policy.configMapRef.key",
 	}, {
 		name: "custom with policy",
 		attestation: Attestation{Name: "second", PredicateType: "custom",

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -261,6 +261,9 @@ type ConfigMapReference struct {
 	// Namespace defines the space within which the configmap name must be unique.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+	// Key defines the key to pull from the configmap.
+	// +optional
+	Key string `json:"key,omitempty"`
 }
 
 // Identity may contain the issuer and/or the subject found in the transparency

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -1054,13 +1054,37 @@ func TestAttestationsValidation(t *testing.T) {
 		},
 		errorString: "invalid value: not-cue: policy.type\nonly [cue,rego] are supported at the moment",
 	}, {
-		name: "custom with missing policy data",
+		name: "custom with missing policy data and configMapRef",
 		attestation: Attestation{Name: "second", PredicateType: "custom",
 			Policy: &Policy{
 				Type: "cue",
 			},
 		},
-		errorString: "missing field(s): policy.data",
+		errorString: "missing field(s): policy.configMapRef, policy.data",
+	}, {
+		name: "custom with both policy data and configMapRef",
+		attestation: Attestation{Name: "second", PredicateType: "custom",
+			Policy: &Policy{
+				Type: "cue",
+				Data: `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
+				ConfigMapRef: &ConfigMapReference{
+					Name: "cmname",
+					Key:  "keyname",
+				},
+			},
+		},
+		errorString: "expected exactly one, got both: policy.configMapRef, policy.data",
+	}, {
+		name: "custom with invalid configMapRef, missing key",
+		attestation: Attestation{Name: "second", PredicateType: "custom",
+			Policy: &Policy{
+				Type: "cue",
+				ConfigMapRef: &ConfigMapReference{
+					Name: "cmname",
+				},
+			},
+		},
+		errorString: "missing field(s): policy.configMapRef.key",
 	}, {
 		name: "custom with policy",
 		attestation: Attestation{Name: "second", PredicateType: "custom",

--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
@@ -72,6 +72,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, cip *v1alpha1.ClusterIma
 		return cipErr
 	}
 
+	cipErr = r.inlinePolicies(ctx, cipCopy)
+	if cipErr != nil {
+		r.handleCIPError(ctx, cip.Name)
+		// Note that we return the error about the Invalid cip here to make
+		// sure that it's surfaced.
+		return cipErr
+	}
+
 	webhookCIP := webhookcip.ConvertClusterImagePolicyV1alpha1ToWebhook(cipCopy)
 
 	// See if the CM holding configs exists
@@ -227,6 +235,63 @@ func (r *Reconciler) inlineAndTrackSecret(ctx context.Context, cip *v1alpha1.Clu
 		}
 		keyref.Data = string(v)
 		keyref.SecretRef = nil
+	}
+	return nil
+}
+
+// inlinePolicies will go through the CIP and try to read the referenced
+// ConfigMapRefs and convert them into inlined data. Modifies the cip in-place
+func (r *Reconciler) inlinePolicies(ctx context.Context, cip *v1alpha1.ClusterImagePolicy) error {
+	for _, authority := range cip.Spec.Authorities {
+		for _, att := range authority.Attestations {
+			if att.Policy != nil && att.Policy.ConfigMapRef != nil {
+				err := r.inlineAndTrackConfigMap(ctx, cip, att.Policy)
+				if err != nil {
+					logging.FromContext(ctx).Errorf("Failed to read configmap %q: %v", att.Policy.ConfigMapRef.Name, err)
+					return err
+				}
+			}
+		}
+	}
+	if cip.Spec.Policy != nil && cip.Spec.Policy.ConfigMapRef != nil {
+		err := r.inlineAndTrackConfigMap(ctx, cip, cip.Spec.Policy)
+		if err != nil {
+			logging.FromContext(ctx).Errorf("Failed to read configmap %q: %v", cip.Spec.Policy.ConfigMapRef.Name, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// inlineAndTrackConfigMap will take in a ConfigMapRef and tries to read the ConfigMap,
+// finding the first key from it and will inline it in place of Data and then
+// clear out the ConfigMapRef and return it.
+// Additionally, we set up a tracker so we will be notified if the ConfigMap
+// is modified.
+func (r *Reconciler) inlineAndTrackConfigMap(ctx context.Context, cip *v1alpha1.ClusterImagePolicy, policyRef *v1alpha1.Policy) error {
+	cmName := policyRef.ConfigMapRef.Name
+	if err := r.tracker.TrackReference(tracker.Reference{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Namespace:  system.Namespace(),
+		Name:       cmName,
+	}, cip); err != nil {
+		return fmt.Errorf("failed to track changes to configmap %q : %w", cmName, err)
+	}
+	cm, err := r.configmaplister.ConfigMaps(system.Namespace()).Get(cmName)
+	if err != nil {
+		return err
+	}
+	if len(cm.Data) == 0 {
+		return fmt.Errorf("configmap %q contains no data", cmName)
+	}
+	if len(cm.Data) > 1 {
+		return fmt.Errorf("configmap %q contains multiple data entries, only one is supported", cmName)
+	}
+	for k, v := range cm.Data {
+		logging.FromContext(ctx).Infof("inlining configmap %q key %q", cmName, k)
+		policyRef.Data = v
+		policyRef.ConfigMapRef = nil
 	}
 	return nil
 }

--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy_test.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy_test.go
@@ -58,6 +58,7 @@ const (
 	kmsKey            = "azure-kms://foo/bar"
 	fakeKMSKey        = "fakekms://keycip"
 	policyCMName      = "policy-configmap"
+	policyCMKey       = "policy-configmap-key"
 
 	testPolicy = `predicateType: "cosign.sigstore.dev/attestation/v1"
 	predicate: Data: "foobar key e2e test"`
@@ -774,12 +775,13 @@ func TestReconcile(t *testing.T) {
 							Policy: &v1alpha1.Policy{
 								ConfigMapRef: &v1alpha1.ConfigMapReference{
 									Name: policyCMName,
+									Key:  policyCMKey,
 								},
 							},
 						}}}),
 				),
 				makeConfigMap(),
-				makePolicyConfigMap(policyCMName, map[string]string{"policy": testPolicy}),
+				makePolicyConfigMap(policyCMName, map[string]string{policyCMKey: testPolicy}),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				makePatch(inlinedPolicyPatch),
@@ -807,11 +809,12 @@ func TestReconcile(t *testing.T) {
 					WithPolicy(&v1alpha1.Policy{
 						ConfigMapRef: &v1alpha1.ConfigMapReference{
 							Name: policyCMName,
+							Key:  policyCMKey,
 						},
 					}),
 				),
 				makeConfigMap(),
-				makePolicyConfigMap(policyCMName, map[string]string{"policy": testPolicy}),
+				makePolicyConfigMap(policyCMName, map[string]string{policyCMKey: testPolicy}),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				makePatch(inlinedCIPPolicyPatch),

--- a/pkg/reconciler/clusterimagepolicy/controller.go
+++ b/pkg/reconciler/clusterimagepolicy/controller.go
@@ -76,6 +76,16 @@ func NewController(
 		),
 	))
 
+	configMapInformer.Informer().AddEventHandler(controller.HandleAll(
+		// Call the tracker's OnChanged method, but we've seen the objects
+		// coming through this path missing TypeMeta, so ensure it is properly
+		// populated.
+		controller.EnsureTypeMeta(
+			r.tracker.OnChanged,
+			corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+		),
+	))
+
 	// When the underlying ConfigMap changes,perform a global resync on
 	// ClusterImagePolicies to make sure their state is correctly reflected
 	// in the ConfigMap. This is admittedly a bit heavy handed, but I don't

--- a/pkg/reconciler/testing/v1alpha1/clusterimagepolicy.go
+++ b/pkg/reconciler/testing/v1alpha1/clusterimagepolicy.go
@@ -71,6 +71,12 @@ func WithAuthority(a v1alpha1.Authority) ClusterImagePolicyOption {
 	}
 }
 
+func WithPolicy(p *v1alpha1.Policy) ClusterImagePolicyOption {
+	return func(cip *v1alpha1.ClusterImagePolicy) {
+		cip.Spec.Policy = p
+	}
+}
+
 func WithMatch(a v1alpha1.MatchResource) ClusterImagePolicyOption {
 	return func(cip *v1alpha1.ClusterImagePolicy) {
 		cip.Spec.Match = append(cip.Spec.Match, a)

--- a/pkg/reconciler/testing/v1alpha1/factory.go
+++ b/pkg/reconciler/testing/v1alpha1/factory.go
@@ -173,6 +173,12 @@ func AssertTrackingSecret(namespace, name string) func(*testing.T, *reconcilerte
 	return AssertTrackingObject(gvk, namespace, name)
 }
 
+// AssertTrackingConfigMap will ensure the provided ConfigMap is being tracked
+func AssertTrackingConfigMap(namespace, name string) func(*testing.T, *reconcilertesting.TableRow) {
+	gvk := corev1.SchemeGroupVersion.WithKind("ConfigMap")
+	return AssertTrackingObject(gvk, namespace, name)
+}
+
 // AssertTrackingObject will ensure the following objects are being tracked
 func AssertTrackingObject(gvk schema.GroupVersionKind, namespace, name string) func(*testing.T, *reconcilertesting.TableRow) {
 	apiVersion, kind := gvk.ToAPIVersionAndKind()

--- a/test/e2e_test_cluster_image_policy_from_configmap_with_fetch_config_file.sh
+++ b/test/e2e_test_cluster_image_policy_from_configmap_with_fetch_config_file.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#set -ex
+set -e
+
+# This is a timestamp server that has multiarch that we just use for testing
+# evaluating CIP level policy validations.
+export demoimage="ghcr.io/sigstore/timestamp-server@sha256:dcf2f3a640bfb0a5d17aabafb34b407fe4403363c715718ab305a62b3606540d"
+
+# To simplify testing failures, use this function to execute a kubectl to create
+# our job and verify that the failure is expected.
+assert_error() {
+  local KUBECTL_OUT_FILE="/tmp/kubectl.failure.out"
+  match="$@"
+  echo looking for ${match}
+  kubectl delete job job-that-fails -n ${NS} --ignore-not-found=true
+  if kubectl create -n ${NS} job job-that-fails --image=${demoimage} 2> ${KUBECTL_OUT_FILE} ; then
+    echo Failed to block expected Job failure!
+    exit 1
+  else
+    echo Successfully blocked Job creation with expected error: "${match}"
+    if ! grep -q "${match}" ${KUBECTL_OUT_FILE} ; then
+      echo Did not get expected failure message, wanted "${match}", got
+      cat ${KUBECTL_OUT_FILE}
+      exit 1
+    fi
+  fi
+}
+
+echo '::group:: Create test namespace and label for verification'
+kubectl create namespace demo-config-file-with-configmap
+kubectl label namespace demo-config-file-with-configmap policy.sigstore.dev/include=true
+export NS=demo-config-file-with-configmap
+echo '::endgroup::'
+
+# Create the configmap that contains our cue policy. Note that as is, it will
+# fail.
+kubectl create -n cosign-system configmap policy-config --from-file=policy=./test/testdata/policies/cue-policy-config.cue
+
+# Note that we put this in a for loop to make sure the webhook is actually
+# up and running before proceeding with the tests.
+echo '::group:: Deploy ClusterImagePolicy with config file that should fail'
+for i in {1..10}
+do
+  if kubectl apply -f ./test/testdata/policy-controller/e2e/cip-config-file-policy-from-configmap.yaml ; then
+    echo successfully applied CIP
+    break
+  fi
+  if [ "$i" == 10 ]; then
+    echo failed to apply CIP
+    exit 1
+  fi
+  echo failed to apply CIP. Attempt numer "$i", retrying
+  sleep 2
+done
+# allow things to propagate
+sleep 5
+echo '::endgroup::'
+
+echo '::group:: validate failure'
+expected_error='failed evaluating cue policy for ClusterImagePolicy: failed to evaluate the policy with error: config."linux/amd64".config.User: conflicting values'
+assert_error ${expected_error}
+echo '::endgroup::'
+
+# Note that we update the configmap here, which should propagate through to the
+# serialized CIP, so testing that as well here.
+echo '::group:: Update configmap with passing values'
+kubectl -n cosign-system get cm -oyaml policy-config | sed  's/65530/65532/' | kubectl apply -f -
+# allow things to propagate
+sleep 5
+echo '::endgroup::'
+
+echo '::group:: test job success'
+# This one should pass since the User is what we specified in the CIP policy.
+if ! kubectl create -n ${NS} job demo --image=${demoimage} ; then
+  echo Failed to create Job in namespace with valid CIP policy!
+  exit 1
+else
+  echo Succcessfully created Job with signed image
+fi
+echo '::endgroup::'
+
+echo '::group::' Cleanup
+kubectl delete cip --all
+kubectl delete ns ${NS}
+echo '::endgroup::'
+

--- a/test/testdata/policies/cue-policy-config.cue
+++ b/test/testdata/policies/cue-policy-config.cue
@@ -1,0 +1,2 @@
+config: "linux/amd64": config: User: "65530"
+config: "linux/arm/v7": config: User: "65530"

--- a/test/testdata/policy-controller/e2e/cip-config-file-policy-from-configmap.yaml
+++ b/test/testdata/policy-controller/e2e/cip-config-file-policy-from-configmap.yaml
@@ -27,3 +27,4 @@ spec:
     type: "cue"
     configMapRef:
       name: policy-config
+      key: policy

--- a/test/testdata/policy-controller/e2e/cip-config-file-policy-from-configmap.yaml
+++ b/test/testdata/policy-controller/e2e/cip-config-file-policy-from-configmap.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-config-file
+spec:
+  images:
+  - glob: "ghcr.io/sigstore/timestamp-server**"
+  authorities:
+  - static:
+      action: pass
+  policy:
+    fetchConfigFile: true
+    type: "cue"
+    configMapRef:
+      name: policy-config


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
* Implement configMapRef in both attestations and CIP level policies. Addresses #454 
* Makes it easier to edit policies so that you don't have to muck with them in the middle of yaml happiness.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Implement configMapRef in both attestations and CIP level policies. Addresses #454 

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->