### PR TITLE
Fix: Fix private multi-arch `fetchConfigFile`

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -1187,7 +1187,7 @@ func getConfigs(ctx context.Context, ref name.Reference, options ...remote.Optio
 					return
 				}
 
-				newRefConfigs, errs := getConfigs(ctx, newRef)
+				newRefConfigs, errs := getConfigs(ctx, newRef, options...)
 				results <- configFileResult{ret: newRefConfigs, errs: errs}
 			}()
 		}
@@ -1201,8 +1201,8 @@ func getConfigs(ctx context.Context, ref name.Reference, options ...remote.Optio
 				if !ok {
 					errs = append(errs, errors.New("channel closed before all results were gathered"))
 				} else {
-					if result.errs != nil {
-						errs = append(errs, fmt.Errorf("failed to get a ConfigFile: %w", err))
+					if len(result.errs) != 0 {
+						errs = append(errs, fmt.Errorf("failed to get a ConfigFile: %v", result.errs))
 					} else {
 						for k, v := range result.ret {
 							ret[k] = v


### PR DESCRIPTION
:bug: This fixes two problems fetching config files for a private multi-arch image:
1. We weren't properly surfacing errors fetching the config files.
2. We weren't passing the `remote.Option` list to the recursive call (so the `remote.WithKeychain` is dropped!)

With these changes downstream, I was able to successfully verify a private multi-arch image index.

/kind bug

Fixes: https://github.com/sigstore/policy-controller/issues/460

#### Release Note

This fixes `fetchConfigFile` for private multi-arch images, and fixes the error message handling along the same path.

#### Documentation

N/A

cc @hectorj2f @vaikas 