### PR TITLE
chore: Relax certificate authority validation in trustRoots

### DIFF
--- a/pkg/apis/policy/v1alpha1/trustroot_validation.go
+++ b/pkg/apis/policy/v1alpha1/trustroot_validation.go
@@ -99,8 +99,8 @@ func (remote *Remote) Validate(ctx context.Context) (errors *apis.FieldError) {
 }
 
 func (sigstoreKeys *SigstoreKeys) Validate(ctx context.Context) (errors *apis.FieldError) {
-	if len(sigstoreKeys.CertificateAuthorities) == 0 {
-		errors = errors.Also(apis.ErrMissingField("certificateAuthority"))
+	if len(sigstoreKeys.CertificateAuthorities) == 0 && len(sigstoreKeys.TimeStampAuthorities) == 0 {
+		errors = errors.Also(apis.ErrMissingOneOf("certificateAuthority", "timestampAuthorities"))
 	} else {
 		for i, ca := range sigstoreKeys.CertificateAuthorities {
 			errors = ValidateCertificateAuthority(ctx, ca).ViaFieldIndex("certificateAuthority", i)

--- a/pkg/apis/policy/v1alpha1/trustroot_validation.go
+++ b/pkg/apis/policy/v1alpha1/trustroot_validation.go
@@ -142,7 +142,7 @@ func ValidateCertificateAuthority(ctx context.Context, ca CertificateAuthority) 
 		errors = errors.Also(apis.ErrMissingField("uri"))
 	}
 	if len(ca.CertChain) == 0 {
-		errors = errors.Also(apis.ErrMissingField("subject"))
+		errors = errors.Also(apis.ErrMissingField("certChain"))
 	}
 	// TODO: Validate the certchain more thorougly.
 	return


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

We could create a TrustRoot with a list of TSAs servers without defining any additional CA.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->