### PR TITLE
Fix: Use the `apiVersion` when matching resources.

### DIFF
--- a/pkg/apis/config/image_policies_test.go
+++ b/pkg/apis/config/image_policies_test.go
@@ -213,6 +213,27 @@ func TestGetAuthorities(t *testing.T) {
 	if got := getAuthority(t, c, matchedPolicy).Sources[0].SignaturePullSecrets[0].Name; got != want {
 		t.Errorf("Did not get what I wanted %q, got %+v", want, got)
 	}
+
+	// Test resource matching
+	c, err = defaults.GetMatchingPolicies("match-pods", "Pod", "v1", map[string]string{"match": "match"})
+	checkGetMatches(t, c, err)
+	if len(c) != 1 {
+		t.Errorf("Wanted 1 match, got %d", len(c))
+	}
+	c, err = defaults.GetMatchingPolicies("match-pods", "Pod", "apps/v1", map[string]string{"match": "match"})
+	if err != nil {
+		t.Fatalf("GetMatchingPolicies() = %v", err)
+	}
+	if len(c) != 0 {
+		t.Errorf("Wanted 0 matches, got %d", len(c))
+	}
+	c, err = defaults.GetMatchingPolicies("match-pods", "Pod", "blah/v1alpha1", map[string]string{"match": "match"})
+	if err != nil {
+		t.Fatalf("GetMatchingPolicies() = %v", err)
+	}
+	if len(c) != 0 {
+		t.Errorf("Wanted 0 matches, got %d", len(c))
+	}
 }
 
 func TestFailsToLoadInvalid(t *testing.T) {

--- a/pkg/apis/config/testdata/config-image-policies.yaml
+++ b/pkg/apis/config/testdata/config-image-policies.yaml
@@ -167,3 +167,32 @@ data:
         - oci: "example.registry.com/alternative/signature"
           signaturePullSecrets:
           - name: examplePullSecret
+    cluster-image-policy-match-pods: |
+      match:
+      - version: v1
+        resource: pods
+      images:
+      - glob: match-pods*
+      authorities:
+      - name: attestation-0
+        key:
+          data: |-
+            -----BEGIN PUBLIC KEY-----
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExB6+H6054/W1SJgs5JR6AJr6J35J
+            RCTfQ5s1kD+hGMSE1rH7s46hmXEeyhnlRnaGF8eMU/SBJE/2NKPnxE7WzQ==
+            -----END PUBLIC KEY-----
+    cluster-image-policy-match-deployments: |
+      match:
+      - group: apps
+        version: v1
+        resource: deployments
+      images:
+      - glob: match-deployments*
+      authorities:
+      - name: attestation-0
+        key:
+          data: |-
+            -----BEGIN PUBLIC KEY-----
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExB6+H6054/W1SJgs5JR6AJr6J35J
+            RCTfQ5s1kD+hGMSE1rH7s46hmXEeyhnlRnaGF8eMU/SBJE/2NKPnxE7WzQ==
+            -----END PUBLIC KEY-----


### PR DESCRIPTION
:bug: I noticed that the resource matching logic was keying exclusively off of `kind` to map to a GVR, and not validating the `apiVersion` which could lead to false positive matches if other types were added to the webhook's resource match.

For example, the code today would match:
```yaml
apiVersion: mattmoor.dev/v1
kind: Deployment
```

However, the new logic does not!  I also tweaked the loop a bit to try and reduce the complexity of the boolean expressions and reduce indentation for readability.

/kind bug

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Release Note

Fixes a bug where `ClusterImagePolicy`'s `match` might apply to resources with mismatched `apiVersion` if those types are let through the webhook.

#### Documentation

N/A