### PR TITLE
Allow fully specified URLs in predicateTypes.

### DIFF
--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -249,7 +250,10 @@ func (a *Attestation) Validate(ctx context.Context) *apis.FieldError {
 	if a.PredicateType == "" {
 		errs = errs.Also(apis.ErrMissingField("predicateType"))
 	} else if !validPredicateTypes.Has(a.PredicateType) {
-		errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "unsupported precicate type"))
+		// This could be a fully specified URL, so check for that here.
+		if _, err := url.ParseRequestURI(a.PredicateType); err != nil {
+			errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "unsupported predicate type"))
+		}
 	}
 	errs = errs.Also(a.Policy.Validate(ctx).ViaField("policy"))
 	return errs

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -971,6 +971,9 @@ func TestAttestationsValidation(t *testing.T) {
 		name:        "vuln",
 		attestation: Attestation{Name: "first", PredicateType: "vuln"},
 	}, {
+		name:        "fully specified URL",
+		attestation: Attestation{Name: "fullyspecified", PredicateType: "https://cyclonedx.org/schema"},
+	}, {
 		name:        "missing name",
 		attestation: Attestation{PredicateType: "vuln"},
 		errorString: "missing field(s): name",
@@ -981,7 +984,7 @@ func TestAttestationsValidation(t *testing.T) {
 	}, {
 		name:        "invalid predicatetype",
 		attestation: Attestation{Name: "first", PredicateType: "notsupported"},
-		errorString: "invalid value: notsupported: predicateType\nunsupported precicate type",
+		errorString: "invalid value: notsupported: predicateType\nunsupported predicate type",
 	}, {
 		name: "custom with invalid policy type",
 		attestation: Attestation{Name: "second", PredicateType: "custom",

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -250,7 +251,10 @@ func (a *Attestation) Validate(ctx context.Context) *apis.FieldError {
 	if a.PredicateType == "" {
 		errs = errs.Also(apis.ErrMissingField("predicateType"))
 	} else if !validPredicateTypes.Has(a.PredicateType) {
-		errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "unsupported precicate type"))
+		// This could be a fully specified URL, so check for that here.
+		if _, err := url.ParseRequestURI(a.PredicateType); err != nil {
+			errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "unsupported predicate type"))
+		}
 	}
 	errs = errs.Also(a.Policy.Validate(ctx).ViaField("policy"))
 	return errs

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -1060,6 +1060,9 @@ func TestAttestationsValidation(t *testing.T) {
 		name:        "vuln",
 		attestation: Attestation{Name: "first", PredicateType: "vuln"},
 	}, {
+		name:        "fully specified URL",
+		attestation: Attestation{Name: "fullyspecified", PredicateType: "https://cyclonedx.org/schema"},
+	}, {
 		name:        "missing name",
 		attestation: Attestation{PredicateType: "vuln"},
 		errorString: "missing field(s): name",
@@ -1070,7 +1073,7 @@ func TestAttestationsValidation(t *testing.T) {
 	}, {
 		name:        "invalid predicatetype",
 		attestation: Attestation{Name: "first", PredicateType: "notsupported"},
-		errorString: "invalid value: notsupported: predicateType\nunsupported precicate type",
+		errorString: "invalid value: notsupported: predicateType\nunsupported predicate type",
 	}, {
 		name: "custom with invalid policy type",
 		attestation: Attestation{Name: "second", PredicateType: "custom",


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Allow Fully specified URLs in the predicate type in addition to 'convenience' ones. 

Got bit by the cyclonedx changing here, which then percolated to cosign, so now you can't validate something that has a type=cyclonedx if the attestation was created with a different version of cosign.

https://github.com/in-toto/in-toto-golang/commit/86e515c6e15f0d9bc2cc9cb8253165f8176f6ce6

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
🎁 Allow fully specified URLs as PredicateTypes.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->