### PR TITLE
Require issuer/subject or issuerRegExp/subjectRegExp

### DIFF
--- a/docs/api-types/index-v1alpha1.md
+++ b/docs/api-types/index-v1alpha1.md
@@ -257,7 +257,7 @@ KeylessRef contains location of the validating certificate and the identities ag
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | url | URL defines a url to the keyless instance. | apis.URL | false |
-| identities | Identities sets a list of identities. | [][Identity](#identity) | false |
+| identities | Identities sets a list of identities. | [][Identity](#identity) | true |
 | ca-cert | CACert sets a reference to CA certificate | [KeyRef](#keyref) | false |
 | trustRootRef | Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog | string | false |
 

--- a/docs/api-types/index.md
+++ b/docs/api-types/index.md
@@ -142,7 +142,7 @@ KeylessRef contains location of the validating certificate and the identities ag
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | url | URL defines a url to the keyless instance. | apis.URL | false |
-| identities | Identities sets a list of identities. | [][Identity](#identity) | false |
+| identities | Identities sets a list of identities. | [][Identity](#identity) | true |
 | ca-cert | CACert sets a reference to CA certificate | [KeyRef](#keyref) | false |
 | trustRootRef | Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog | string | false |
 

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -177,8 +177,7 @@ type KeylessRef struct {
 	// +optional
 	URL *apis.URL `json:"url,omitempty"`
 	// Identities sets a list of identities.
-	// +optional
-	Identities []Identity `json:"identities,omitempty"`
+	Identities []Identity `json:"identities"`
 	// CACert sets a reference to CA certificate
 	// +optional
 	CACert *KeyRef `json:"ca-cert,omitempty"`

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -214,9 +214,9 @@ func (keyless *KeylessRef) Validate(ctx context.Context) *apis.FieldError {
 	if keyless.CACert != nil {
 		errs = errs.Also(keyless.DeepCopy().CACert.Validate(ctx).ViaField("ca-cert"))
 	}
-	// Warn if there are no identities specified
+	// Check that identities is specified.
 	if len(keyless.Identities) == 0 {
-		errs = errs.Also(apis.ErrMissingField("identities").At(apis.WarningLevel))
+		errs = errs.Also(apis.ErrMissingField("identities"))
 	}
 	for i, identity := range keyless.Identities {
 		errs = errs.Also(identity.Validate(ctx).ViaFieldIndex("identities", i))
@@ -318,10 +318,10 @@ func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(ValidateRegex(identity.SubjectRegExp).ViaField("subjectRegExp"))
 	}
 	if identity.SubjectRegExp == "" && identity.Subject == "" {
-		errs = errs.Also(apis.ErrMissingField("subject", "subjectRegExp").At(apis.WarningLevel))
+		errs = errs.Also(apis.ErrMissingField("subject", "subjectRegExp"))
 	}
 	if identity.IssuerRegExp == "" && identity.Issuer == "" {
-		errs = errs.Also(apis.ErrMissingField("issuer", "issuerRegExp").At(apis.WarningLevel))
+		errs = errs.Also(apis.ErrMissingField("issuer", "issuerRegExp"))
 	}
 	return errs
 }

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -226,12 +226,10 @@ func TestKeylessValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name:        "Should fail when keyless is empty",
-		errorString: "expected exactly one, got neither: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url",
-		warnString:  "missing field(s): spec.authorities[0].keyless.identities",
+		errorString: "expected exactly one, got neither: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url\nmissing field(s): spec.authorities[0].keyless.identities",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -248,8 +246,7 @@ func TestKeylessValidation(t *testing.T) {
 		},
 	}, {
 		name:        "Should fail when keyless has multiple properties",
-		errorString: "expected exactly one, got both: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url",
-		warnString:  "missing field(s): spec.authorities[0].keyless.identities",
+		errorString: "expected exactly one, got both: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url\nmissing field(s): spec.authorities[0].keyless.identities",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -272,8 +269,8 @@ func TestKeylessValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:       "Should warn when valid keyless ref is specified, but no identities given",
-		warnString: "missing field(s): spec.authorities[0].keyless.identities",
+		name:        "Should warn when valid keyless ref is specified, but no identities given",
+		errorString: "missing field(s): spec.authorities[0].keyless.identities",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -324,7 +321,7 @@ func TestKeylessValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.policy.Validate(context.TODO())
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }
@@ -534,7 +531,6 @@ func TestAuthoritiesValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name:        "Should fail when authority is empty",
@@ -761,8 +757,7 @@ func TestAuthoritiesValidation(t *testing.T) {
 		},
 	}, {
 		name:        "Should fail with invalid AWS KMS for Keyless",
-		errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].keyless.ca-cert.kms\nfailed to parse either key or alias arn: arn: not enough sections",
-		warnString:  "missing field(s): spec.authorities[0].keyless.identities",
+		errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].keyless.ca-cert.kms\nfailed to parse either key or alias arn: arn: not enough sections\nmissing field(s): spec.authorities[0].keyless.identities",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{{Glob: "gcr.io/*"}},
@@ -957,7 +952,7 @@ func TestAuthoritiesValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.policy.Validate(context.TODO())
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }
@@ -1048,7 +1043,6 @@ func TestIdentitiesValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name: "Should pass with identities",
@@ -1072,8 +1066,8 @@ func TestIdentitiesValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:       "Should warn when identities fields are empty",
-		warnString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp, spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
+		name:        "Should warn when identities fields are empty",
+		errorString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp, spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -1163,8 +1157,8 @@ func TestIdentitiesValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:       "Should warn when issuer or issuerRegExp is missing",
-		warnString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp",
+		name:        "Should warn when issuer or issuerRegExp is missing",
+		errorString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -1186,8 +1180,8 @@ func TestIdentitiesValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:       "Should warn when subject or subjectRegExp is missing",
-		warnString: "missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
+		name:        "Should warn when subject or subjectRegExp is missing",
+		errorString: "missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -1285,7 +1279,7 @@ func TestIdentitiesValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.policy.Validate(context.TODO())
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }
@@ -1356,7 +1350,6 @@ func TestMatchValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name: "Should pass with identities",
@@ -1496,7 +1489,7 @@ func TestMatchValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.policy.Validate(context.TODO())
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }
@@ -1504,6 +1497,10 @@ func TestMatchValidation(t *testing.T) {
 // validateError checks the given error against wanted error/warning strings
 // if either is "" then it's assume an error/warning is not wanted and if
 // one is given, will error.
+// nolint since currently we do not have warnings we expect, but having this
+// around makes it easier to add warning validations in the future.
+//
+//nolint:all
 func validateError(t *testing.T, wantErrStr, wantWarnStr string, fe *apis.FieldError) {
 	t.Helper()
 	// Grab warning and check it first

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -176,8 +176,7 @@ type KeylessRef struct {
 	// +optional
 	URL *apis.URL `json:"url,omitempty"`
 	// Identities sets a list of identities.
-	// +optional
-	Identities []Identity `json:"identities,omitempty"`
+	Identities []Identity `json:"identities"`
 	// CACert sets a reference to CA certificate
 	// +optional
 	CACert *KeyRef `json:"ca-cert,omitempty"`

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -215,9 +215,9 @@ func (keyless *KeylessRef) Validate(ctx context.Context) *apis.FieldError {
 	if keyless.CACert != nil {
 		errs = errs.Also(keyless.DeepCopy().CACert.Validate(ctx).ViaField("ca-cert"))
 	}
-	// Warn if there are no identities specified
+	// Check that identities is specified.
 	if len(keyless.Identities) == 0 {
-		errs = errs.Also(apis.ErrMissingField("identities").At(apis.WarningLevel))
+		errs = errs.Also(apis.ErrMissingField("identities"))
 	}
 	for i, identity := range keyless.Identities {
 		errs = errs.Also(identity.Validate(ctx).ViaFieldIndex("identities", i))
@@ -319,10 +319,10 @@ func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(ValidateRegex(identity.SubjectRegExp).ViaField("subjectRegExp"))
 	}
 	if identity.SubjectRegExp == "" && identity.Subject == "" {
-		errs = errs.Also(apis.ErrMissingField("subject", "subjectRegExp").At(apis.WarningLevel))
+		errs = errs.Also(apis.ErrMissingField("subject", "subjectRegExp"))
 	}
 	if identity.IssuerRegExp == "" && identity.Issuer == "" {
-		errs = errs.Also(apis.ErrMissingField("issuer", "issuerRegExp").At(apis.WarningLevel))
+		errs = errs.Also(apis.ErrMissingField("issuer", "issuerRegExp"))
 	}
 	return errs
 }

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -274,12 +274,10 @@ func TestKeylessValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name:        "Should fail when keyless is empty",
-		errorString: "expected exactly one, got neither: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url",
-		warnString:  "missing field(s): spec.authorities[0].keyless.identities",
+		errorString: "expected exactly one, got neither: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url\nmissing field(s): spec.authorities[0].keyless.identities",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -296,8 +294,7 @@ func TestKeylessValidation(t *testing.T) {
 		},
 	}, {
 		name:        "Should fail when keyless has multiple properties",
-		errorString: "expected exactly one, got both: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url",
-		warnString:  "missing field(s): spec.authorities[0].keyless.identities",
+		errorString: "expected exactly one, got both: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url\nmissing field(s): spec.authorities[0].keyless.identities",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -320,8 +317,8 @@ func TestKeylessValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:       "Should warn when valid keyless ref is specified, but no identities given",
-		warnString: "missing field(s): spec.authorities[0].keyless.identities",
+		name:        "Should warn when valid keyless ref is specified, but no identities given",
+		errorString: "missing field(s): spec.authorities[0].keyless.identities",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -372,7 +369,7 @@ func TestKeylessValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.policy.Validate(context.TODO())
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }
@@ -582,7 +579,6 @@ func TestAuthoritiesValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name:        "Should fail when authority is empty",
@@ -784,8 +780,7 @@ func TestAuthoritiesValidation(t *testing.T) {
 		},
 	}, {
 		name:        "Should fail with invalid AWS KMS for Keyless",
-		errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].keyless.ca-cert.kms\nfailed to parse either key or alias arn: arn: not enough sections",
-		warnString:  "missing field(s): spec.authorities[0].keyless.identities",
+		errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].keyless.ca-cert.kms\nfailed to parse either key or alias arn: arn: not enough sections\nmissing field(s): spec.authorities[0].keyless.identities",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{{Glob: "gcr.io/*"}},
@@ -1019,7 +1014,7 @@ func TestAuthoritiesValidation(t *testing.T) {
 			testContext := policycontrollerconfig.ToContext(context.TODO(), &policycontrollerconfig.PolicyControllerConfig{NoMatchPolicy: policycontrollerconfig.AllowAll, FailOnEmptyAuthorities: true})
 
 			err := test.policy.Validate(testContext)
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }
@@ -1028,7 +1023,6 @@ func TestEmptyAuthoritiesValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name: "Should pass when Authorities is empty",
@@ -1046,7 +1040,7 @@ func TestEmptyAuthoritiesValidation(t *testing.T) {
 			testContext := policycontrollerconfig.ToContext(context.TODO(), &policycontrollerconfig.PolicyControllerConfig{NoMatchPolicy: policycontrollerconfig.AllowAll, FailOnEmptyAuthorities: false})
 
 			err := test.policy.Validate(testContext)
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }
@@ -1137,7 +1131,6 @@ func TestIdentitiesValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name: "Should pass with identities",
@@ -1161,8 +1154,8 @@ func TestIdentitiesValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:       "Should warn when identities fields are empty",
-		warnString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp, spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
+		name:        "Should warn when identities fields are empty",
+		errorString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp, spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -1252,8 +1245,8 @@ func TestIdentitiesValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:       "Should warn when issuer or issuerRegExp is missing",
-		warnString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp",
+		name:        "Should warn when issuer or issuerRegExp is missing",
+		errorString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -1275,8 +1268,8 @@ func TestIdentitiesValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:       "Should warn when subject or subjectRegExp is missing",
-		warnString: "missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
+		name:        "Should warn when subject or subjectRegExp is missing",
+		errorString: "missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -1374,7 +1367,7 @@ func TestIdentitiesValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.policy.Validate(context.TODO())
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }
@@ -1439,6 +1432,10 @@ func TestAWSKMSValidation(t *testing.T) {
 // validateError checks the given error against wanted error/warning strings
 // if either is "" then it's assume an error/warning is not wanted and if
 // one is given, will error.
+// nolint since currently we do not have warnings we expect, but having this
+// around makes it easier to add warning validations in the future.
+//
+//nolint:all
 func validateError(t *testing.T, wantErrStr, wantWarnStr string, fe *apis.FieldError) {
 	t.Helper()
 	// Grab warning and check it first
@@ -1464,7 +1461,6 @@ func TestMatchValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
-		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name: "Should pass with identities",
@@ -1605,7 +1601,7 @@ func TestMatchValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.policy.Validate(context.TODO())
-			validateError(t, test.errorString, test.warnString, err)
+			validateError(t, test.errorString, "", err)
 		})
 	}
 }

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -41,25 +41,6 @@ spec:
       url: https://rekor.sigstore.dev
 `
 
-	// This is a policy that has warnings when compiled because it is missing
-	// identity verification in its keyless block.
-	warnPolicy = `
-apiVersion: policy.sigstore.dev/v1beta1
-kind: ClusterImagePolicy
-metadata:
-  name: ko-default-base-image-policy
-spec:
-  images:
-  - glob: cgr.dev/chainguard/static*
-  authorities:
-  - keyless:
-      url: https://fulcio.sigstore.dev
-    # TODO(https://github.com/sigstore/policy-controller/issues/479):
-    # Remove this once the above is fixed.
-    ctlog:
-      url: https://rekor.sigstore.dev
-`
-
 	badPolicy = `
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -136,7 +136,7 @@ spec: {}
 `,
 		wantErr: errors.New(`unknown type: unknown.dev/v1, Kind=OtherPolicy`),
 	}, {
-		name: "warning - missing field",
+		name: "error - missing field",
 		doc: `
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy
@@ -149,8 +149,7 @@ spec:
   - keyless:
       url: https://fulcio.sigstore.dev
 `,
-		wantWarns: errors.New("missing field(s): spec.authorities[0].keyless.identities"),
-		wantErr:   nil,
+		wantErr: errors.New("missing field(s): spec.authorities[0].keyless.identities"),
 	},
 		{
 			name: "admit - missing authorities",

--- a/pkg/policy/verifier_test.go
+++ b/pkg/policy/verifier_test.go
@@ -137,16 +137,6 @@ func TestVerifierWarn(t *testing.T) {
 		},
 		d:       name.MustParseReference("cgr.dev/chainguard/static@" + staticDigest).(name.Digest),
 		wantErr: errors.New(`duplicate policy named "ko-default-base-image-policy", skipping`),
-	}, {
-		name: "compilation warnings",
-		v: Verification{
-			NoMatchPolicy: "deny", // This is always surfaced as a warning.
-			Policies: &[]Source{{
-				Data: warnPolicy,
-			}},
-		},
-		d:       name.MustParseReference("cgr.dev/chainguard/static@" + ancientDigest).(name.Digest),
-		wantErr: errors.New(`policy 0: missing field(s): spec.authorities[0].keyless.identities`),
 	}}
 
 	for _, test := range tests {

--- a/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
@@ -33,5 +33,8 @@ spec:
       url: http://rekor.rekor-system.svc
   - keyless:
       url: http://fulcio.sigstore.dev
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.sigstore.dev

--- a/test/testdata/policy-controller/e2e/cip-keyless-warn.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-warn.yaml
@@ -23,5 +23,9 @@ spec:
   authorities:
   - keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
+

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-attestations-rego.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-attestations-rego.yaml
@@ -23,6 +23,9 @@ spec:
   - name: attestation
     keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
@@ -23,6 +23,9 @@ spec:
   - name: attestation
     keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-source.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-source.yaml
@@ -22,6 +22,9 @@ spec:
   authorities:
   - keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     source:
     - oci: registry.local:5000/policy-controller/demo
     ctlog:

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-remote-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-remote-with-attestations.yaml
@@ -24,6 +24,9 @@ spec:
     keyless:
       url: http://fulcio.fulcio-system.svc
       trustRootRef: my-remote
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
       trustRootRef: my-remote

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-repository-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-repository-with-attestations.yaml
@@ -24,6 +24,9 @@ spec:
     keyless:
       url: http://fulcio.fulcio-system.svc
       trustRootRef: my-repository-serialized
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
       trustRootRef: my-repository-serialized

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-with-attestations.yaml
@@ -24,6 +24,9 @@ spec:
     keyless:
       url: http://fulcio.fulcio-system.svc
       trustRootRef: my-sigstore-keys
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
       trustRootRef: my-sigstore-keys

--- a/test/testdata/policy-controller/e2e/cip-keyless.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless.yaml
@@ -22,5 +22,8 @@ spec:
   authorities:
   - keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc

--- a/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations-rego.yaml
+++ b/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations-rego.yaml
@@ -23,6 +23,9 @@ spec:
   - name: keylessatt
     keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:
@@ -81,6 +84,9 @@ spec:
   - name: keylesssignature
     keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
   - name: keysignature

--- a/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml
@@ -23,6 +23,9 @@ spec:
   - name: keylessatt
     keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:
@@ -81,6 +84,9 @@ spec:
   - name: keylesssignature
     keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
   - name: keysignature

--- a/test/testdata/policy-controller/invalid/empty-keyref-and-keylessref.yaml
+++ b/test/testdata/policy-controller/invalid/empty-keyref-and-keylessref.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# ERROR:expected exactly one, got both: spec.authorities[0].key, spec.authorities[0].keyless, spec.authorities[0].rfc3161timestamp, spec.authorities[0].static
+# ERROR:keyless.identities: Invalid value
 apiVersion: policy.sigstore.dev/v1alpha1
 kind: ClusterImagePolicy
 metadata:

--- a/test/testdata/policy-controller/invalid/keylessref-with-multiple-properties.yaml
+++ b/test/testdata/policy-controller/invalid/keylessref-with-multiple-properties.yaml
@@ -22,6 +22,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         secretRef:
           name: ca-cert-secret

--- a/test/testdata/policy-controller/invalid/missing-identity.yaml
+++ b/test/testdata/policy-controller/invalid/missing-identity.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp
+# ERROR:spec.authorities.keyless.identities: Invalid value
 apiVersion: policy.sigstore.dev/v1alpha1
 kind: ClusterImagePolicy
 metadata:
-  name: image-policy-missing-issuer
+  name: image-policy-missing-identity
 spec:
   mode: warn
   images:
@@ -24,5 +24,3 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
-      identities:
-      - subject: "testsubject"

--- a/test/testdata/policy-controller/invalid/missing-identity.yaml
+++ b/test/testdata/policy-controller/invalid/missing-identity.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ERROR:spec.authorities.keyless.identities: Invalid value
+# ERROR:keyless.identities: Invalid value
 apiVersion: policy.sigstore.dev/v1alpha1
 kind: ClusterImagePolicy
 metadata:

--- a/test/testdata/policy-controller/invalid/missing-issuer.yaml
+++ b/test/testdata/policy-controller/invalid/missing-issuer.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp
-apiVersion: policy.sigstore.dev/v1beta1
+# ERROR:missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp
+apiVersion: policy.sigstore.dev/v1alpha1
 kind: ClusterImagePolicy
 metadata:
-  name: image-policy-missing-issuer-v1beta1
+  name: image-policy-missing-issuer
 spec:
   mode: warn
   images:

--- a/test/testdata/policy-controller/invalid/missing-subject.yaml
+++ b/test/testdata/policy-controller/invalid/missing-subject.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: missing field(s): spec.authorities[0].keyless.identities
+# ERROR:missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp
 apiVersion: policy.sigstore.dev/v1alpha1
 kind: ClusterImagePolicy
 metadata:
-  name: image-policy-missing-identity
+  name: image-policy-missing-subject
 spec:
   mode: warn
   images:
@@ -24,3 +24,5 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
+      identities:
+      - issuer: "testissuer"

--- a/test/testdata/policy-controller/invalid/v1beta1-empty-keyref-and-keylessref.yaml
+++ b/test/testdata/policy-controller/invalid/v1beta1-empty-keyref-and-keylessref.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# ERROR:expected exactly one, got both: spec.authorities[0].key, spec.authorities[0].keyless, spec.authorities[0].rfc3161timestamp, spec.authorities[0].static
+# ERROR:keyless.identities: Invalid value
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy
 metadata:

--- a/test/testdata/policy-controller/invalid/v1beta1-keylessref-with-multiple-properties.yaml
+++ b/test/testdata/policy-controller/invalid/v1beta1-keylessref-with-multiple-properties.yaml
@@ -22,6 +22,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         secretRef:
           name: ca-cert-secret

--- a/test/testdata/policy-controller/invalid/v1beta1-missing-identity.yaml
+++ b/test/testdata/policy-controller/invalid/v1beta1-missing-identity.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp
+# ERROR:spec.authorities.keyless.identities: Invalid value
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy
 metadata:
-  name: image-policy-missing-subject-v1beta1
+  name: image-policy-missing-identity-v1beta1
 spec:
   mode: warn
   images:
@@ -24,5 +24,3 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
-      identities:
-      - issuer: "testissuer"

--- a/test/testdata/policy-controller/invalid/v1beta1-missing-identity.yaml
+++ b/test/testdata/policy-controller/invalid/v1beta1-missing-identity.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ERROR:spec.authorities.keyless.identities: Invalid value
+# ERROR:keyless.identities: Invalid value
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy
 metadata:

--- a/test/testdata/policy-controller/invalid/v1beta1-missing-issuer.yaml
+++ b/test/testdata/policy-controller/invalid/v1beta1-missing-issuer.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: missing field(s): spec.authorities[0].keyless.identities
+# ERROR:missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy
 metadata:
-  name: image-policy-missing-identity-v1beta1
+  name: image-policy-missing-issuer-v1beta1
 spec:
   mode: warn
   images:
@@ -24,3 +24,5 @@ spec:
   authorities:
   - keyless:
       url: https://fulcio.sigstore.dev
+      identities:
+      - subject: "testsubject"

--- a/test/testdata/policy-controller/invalid/v1beta1-missing-subject.yaml
+++ b/test/testdata/policy-controller/invalid/v1beta1-missing-subject.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp
-apiVersion: policy.sigstore.dev/v1alpha1
+# ERROR:missing field(s): spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp
+apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy
 metadata:
-  name: image-policy-missing-subject
+  name: image-policy-missing-subject-v1beta1
 spec:
   mode: warn
   images:

--- a/test/testdata/policy-controller/valid/v1beta1-valid-keylessref-awskms.yaml
+++ b/test/testdata/policy-controller/valid/v1beta1-valid-keylessref-awskms.yaml
@@ -21,14 +21,26 @@ spec:
   - glob: images.*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         kms: "awskms:///arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
   - keyless:
-       ca-cert:
-         kms: "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
+      ca-cert:
+        kms: "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
   - keyless:
-       ca-cert:
-         kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
+      ca-cert:
+        kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"

--- a/test/testdata/policy-controller/valid/v1beta1-valid-policy-glob.yaml
+++ b/test/testdata/policy-controller/valid/v1beta1-valid-policy-glob.yaml
@@ -22,6 +22,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuer: "issue-details"
+        subject: "subject-details"
       ca-cert:
         secretRef:
           name: ca-cert-secret
@@ -33,6 +36,7 @@ spec:
   - keyless:
       identities:
       - issuer: "issue-details1"
+        subject: "subject-details1"
   - key:
       data: |
         -----BEGIN PUBLIC KEY-----

--- a/test/testdata/policy-controller/valid/v1beta1-valid-policy.yaml
+++ b/test/testdata/policy-controller/valid/v1beta1-valid-policy.yaml
@@ -22,6 +22,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuer: "issue-details"
+        subject: "subject-details"
       ca-cert:
         secretRef:
           name: ca-cert-secret
@@ -77,7 +80,8 @@ spec:
         subjectRegExp: ".*subject.*"
   - keyless:
       identities:
-      - issuer: "issue.*"
+      - issuerRegExp: "issue.*"
+        subject: "subject"
   - key:
       data: |
         -----BEGIN PUBLIC KEY-----

--- a/test/testdata/policy-controller/valid/valid-keyless-with-source.yaml
+++ b/test/testdata/policy-controller/valid/valid-keyless-with-source.yaml
@@ -21,6 +21,9 @@ spec:
   - glob: images.*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         secretRef:
           name: ca-cert-secret

--- a/test/testdata/policy-controller/valid/valid-keylessref-awskms.yaml
+++ b/test/testdata/policy-controller/valid/valid-keylessref-awskms.yaml
@@ -21,14 +21,26 @@ spec:
   - glob: images.*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         kms: "awskms:///arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
        ca-cert:
          kms: "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
        ca-cert:
          kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"

--- a/test/testdata/policy-controller/valid/valid-keylessref-awskms.yaml
+++ b/test/testdata/policy-controller/valid/valid-keylessref-awskms.yaml
@@ -36,11 +36,11 @@ spec:
       identities:
       - issuerRegExp: .*kubernetes.default.*
         subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
-       ca-cert:
-         kms: "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
+      ca-cert:
+        kms: "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
   - keyless:
       identities:
       - issuerRegExp: .*kubernetes.default.*
         subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
-       ca-cert:
-         kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
+      ca-cert:
+        kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"

--- a/test/testdata/policy-controller/valid/valid-policy-glob.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy-glob.yaml
@@ -23,6 +23,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         secretRef:
           name: ca-cert-secret

--- a/test/testdata/policy-controller/valid/valid-policy-glob.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy-glob.yaml
@@ -37,6 +37,7 @@ spec:
   - keyless:
       identities:
       - issuer: "issue-details1"
+        subject: "subject-details1"
   - key:
       data: |
         -----BEGIN PUBLIC KEY-----

--- a/test/testdata/policy-controller/valid/valid-policy-hash-algo.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy-hash-algo.yaml
@@ -23,6 +23,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         secretRef:
           name: ca-cert-secret
@@ -78,7 +81,8 @@ spec:
         subjectRegExp: ".*subject.*"
   - keyless:
       identities:
-      - issuer: "issue.*"
+      - issuerRegExp: "issue.*"
+        subject: "subject"
   - key:
       hashAlgorithm: sha256
       data: |

--- a/test/testdata/policy-controller/valid/valid-policy-match-resource-label.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy-match-resource-label.yaml
@@ -30,6 +30,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         secretRef:
           name: ca-cert-secret
@@ -85,7 +88,8 @@ spec:
         subjectRegExp: ".*subject.*"
   - keyless:
       identities:
-      - issuer: "issue.*"
+      - issuerRegExp: "issue.*"
+        subject: "subject"
   - key:
       data: |
         -----BEGIN PUBLIC KEY-----

--- a/test/testdata/policy-controller/valid/valid-policy-match-resource.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy-match-resource.yaml
@@ -27,6 +27,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
       ca-cert:
         secretRef:
           name: ca-cert-secret
@@ -82,7 +85,8 @@ spec:
         subjectRegExp: ".*subject.*"
   - keyless:
       identities:
-      - issuer: "issue.*"
+      - issuerRegExp: "issue.*"
+        subject: "subject"
   - key:
       data: |
         -----BEGIN PUBLIC KEY-----

--- a/test/testdata/policy-controller/valid/valid-policy.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy.yaml
@@ -23,6 +23,9 @@ spec:
   - glob: image*
   authorities:
   - keyless:
+      identities:
+      - issuer: "issue-details"
+        subject: "subject-details"
       ca-cert:
         secretRef:
           name: ca-cert-secret
@@ -78,7 +81,8 @@ spec:
         subjectRegExp: ".*subject.*"
   - keyless:
       identities:
-      - issuer: "issue.*"
+      - issuerRegExp: "issue.*"
+        subject: "subject"
   - key:
       data: |
         -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
These fields have been warning about missing since August. Upstream now requires them so we have to make the cutover.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
💥  BREAKING CHANGE: issuer/subject or issuerRegExp/subjectRegExp are now require fields. They've been warning since August, and upstream changes require this now.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->