### PR TITLE
update test to expected condition

### DIFF
--- a/test/testdata/policy-controller/invalid/v1beta1-empty-keyref-and-keylessref.yaml
+++ b/test/testdata/policy-controller/invalid/v1beta1-empty-keyref-and-keylessref.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-# ERROR:keyless.identities: Invalid value
+# ERROR:expected exactly one, got both: spec.authorities[0].key, spec.authorities[0].keyless, spec.authorities[0].rfc3161timestamp, spec.authorities[0].static
 apiVersion: policy.sigstore.dev/v1beta1
 kind: ClusterImagePolicy
 metadata:
@@ -21,5 +21,6 @@ spec:
   images:
   - glob: image*
   authorities:
-  - keyless: {}
+  - keyless:
+      identities:
     key: {}


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Tweak the test to be more consistent.
It is my understanding that the [`invalid/v1beta1-empty-keyref-and-keylessref.yaml`](https://github.com/sigstore/policy-controller/blob/main/test/testdata/policy-controller/invalid/v1beta1-empty-keyref-and-keylessref.yaml) test fails with

```The ClusterImagePolicy "image-policy" is invalid: spec.authorities.keyless.identities: Invalid value: "null": spec.authorities.keyless.identities in body must be of type array: "null"```

is because of the conversion that is taking place from v1beta1 to v1alpha1.

when the webhook conversion unmarshal and re-marshal it, it caused the `identity` field to be defaulted as it doesnt have `omitempty` anymore.
so rather than an empty `keyless` field, it has an empty `identity` field which causes it to fail differently than in opensource.

before conversion
```
spec:
  images:
  - glob: image*
  authorities:
  - keyless: {}
    key: {}
```
after conversion
```
spec:
  images:
  - glob: image*
  authorities:
  - keyless:
      identities:
    key: {}
```
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->