### PR TITLE
WIP: Add a new API field to skip tlog verifications for keyless

### DIFF
--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -181,6 +181,8 @@ spec:
                                 subjectRegExp:
                                   description: SubjectRegExp specifies a regular expression to match the subject for this identity.
                                   type: string
+                          skipTlogVerify:
+                            type: boolean
                           trustRootRef:
                             description: Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog
                             type: string
@@ -453,6 +455,8 @@ spec:
                                 subjectRegExp:
                                   description: SubjectRegExp specifies a regular expression to match the subject for this identity.
                                   type: string
+                          skipTlogVerify:
+                            type: boolean
                           trustRootRef:
                             description: Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog
                             type: string

--- a/docs/api-types/index-v1alpha1.md
+++ b/docs/api-types/index-v1alpha1.md
@@ -260,6 +260,7 @@ KeylessRef contains location of the validating certificate and the identities ag
 | identities | Identities sets a list of identities. | [][Identity](#identity) | true |
 | ca-cert | CACert sets a reference to CA certificate | [KeyRef](#keyref) | false |
 | trustRootRef | Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog | string | false |
+| skipTlogVerify |  | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/api-types/index.md
+++ b/docs/api-types/index.md
@@ -145,6 +145,7 @@ KeylessRef contains location of the validating certificate and the identities ag
 | identities | Identities sets a list of identities. | [][Identity](#identity) | true |
 | ca-cert | CACert sets a reference to CA certificate | [KeyRef](#keyref) | false |
 | trustRootRef | Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog | string | false |
+| skipTlogVerify |  | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -185,7 +185,7 @@ type KeylessRef struct {
 	// +optional
 	TrustRootRef string `json:"trustRootRef,omitempty"`
 	// +optional
-	SkipTlogVerify *bool `json:"skipTlogVerify,omitempty"`
+	IgnoreTlog *bool `json:"skipTlogVerify,omitempty"`
 }
 
 // Attestation defines the type of attestation to validate and optionally

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -184,6 +184,8 @@ type KeylessRef struct {
 	// Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog
 	// +optional
 	TrustRootRef string `json:"trustRootRef,omitempty"`
+	// +optional
+	SkipTlogVerify *bool `json:"skipTlogVerify,omitempty"`
 }
 
 // Attestation defines the type of attestation to validate and optionally

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -328,6 +328,11 @@ func (in *KeylessRef) DeepCopyInto(out *KeylessRef) {
 		*out = new(KeyRef)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SkipTlogVerify != nil {
+		in, out := &in.SkipTlogVerify, &out.SkipTlogVerify
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -328,8 +328,8 @@ func (in *KeylessRef) DeepCopyInto(out *KeylessRef) {
 		*out = new(KeyRef)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.SkipTlogVerify != nil {
-		in, out := &in.SkipTlogVerify, &out.SkipTlogVerify
+	if in.IgnoreTlog != nil {
+		in, out := &in.IgnoreTlog, &out.IgnoreTlog
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -183,6 +183,8 @@ type KeylessRef struct {
 	// Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog
 	// +optional
 	TrustRootRef string `json:"trustRootRef,omitempty"`
+	// +optional
+	SkipTlogVerify *bool `json:"skipTlogVerify,omitempty"`
 }
 
 // Attestation defines the type of attestation to validate and optionally

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -184,7 +184,7 @@ type KeylessRef struct {
 	// +optional
 	TrustRootRef string `json:"trustRootRef,omitempty"`
 	// +optional
-	SkipTlogVerify *bool `json:"skipTlogVerify,omitempty"`
+	IgnoreTlog *bool `json:"skipTlogVerify,omitempty"`
 }
 
 // Attestation defines the type of attestation to validate and optionally

--- a/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
@@ -289,6 +289,11 @@ func (in *KeylessRef) DeepCopyInto(out *KeylessRef) {
 		*out = new(KeyRef)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SkipTlogVerify != nil {
+		in, out := &in.SkipTlogVerify, &out.SkipTlogVerify
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
@@ -289,8 +289,8 @@ func (in *KeylessRef) DeepCopyInto(out *KeylessRef) {
 		*out = new(KeyRef)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.SkipTlogVerify != nil {
-		in, out := &in.SkipTlogVerify, &out.SkipTlogVerify
+	if in.IgnoreTlog != nil {
+		in, out := &in.IgnoreTlog, &out.IgnoreTlog
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/webhook/clusterimagepolicy/clusterimagepolicy_types.go
+++ b/pkg/webhook/clusterimagepolicy/clusterimagepolicy_types.go
@@ -117,7 +117,7 @@ type KeylessRef struct {
 	// +optional
 	TrustRootRef string `json:"trustRootRef,omitempty"`
 	// +optional
-	SkipTlogVerify *bool `json:"skipTlogVerify,omitempty"`
+	IgnoreTlog *bool `json:"ignoreTlog,omitempty"`
 }
 
 type StaticRef struct {
@@ -387,11 +387,11 @@ func convertKeylessRefV1Alpha1ToWebhook(in *v1alpha1.KeylessRef) *KeylessRef {
 	CACertRef := convertKeyRefV1Alpha1ToWebhook(in.CACert)
 
 	return &KeylessRef{
-		URL:            in.URL,
-		Identities:     in.Identities,
-		CACert:         CACertRef,
-		TrustRootRef:   in.TrustRootRef,
-		SkipTlogVerify: in.SkipTlogVerify,
+		URL:          in.URL,
+		Identities:   in.Identities,
+		CACert:       CACertRef,
+		TrustRootRef: in.TrustRootRef,
+		IgnoreTlog:   in.IgnoreTlog,
 	}
 }
 

--- a/pkg/webhook/clusterimagepolicy/clusterimagepolicy_types.go
+++ b/pkg/webhook/clusterimagepolicy/clusterimagepolicy_types.go
@@ -116,6 +116,8 @@ type KeylessRef struct {
 	// Use the Certificate Chain from the referred TrustRoot.CertificateAuthorities and TrustRoot.CTLog
 	// +optional
 	TrustRootRef string `json:"trustRootRef,omitempty"`
+	// +optional
+	SkipTlogVerify *bool `json:"skipTlogVerify,omitempty"`
 }
 
 type StaticRef struct {
@@ -385,10 +387,11 @@ func convertKeylessRefV1Alpha1ToWebhook(in *v1alpha1.KeylessRef) *KeylessRef {
 	CACertRef := convertKeyRefV1Alpha1ToWebhook(in.CACert)
 
 	return &KeylessRef{
-		URL:          in.URL,
-		Identities:   in.Identities,
-		CACert:       CACertRef,
-		TrustRootRef: in.TrustRootRef,
+		URL:            in.URL,
+		Identities:     in.Identities,
+		CACert:         CACertRef,
+		TrustRootRef:   in.TrustRootRef,
+		SkipTlogVerify: in.SkipTlogVerify,
 	}
 }
 

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -1298,25 +1298,26 @@ func checkOptsFromAuthority(ctx context.Context, authority webhookcip.Authority,
 		ret.IntermediateCerts = fulcioIntermediates
 		ret.CTLogPubKeys = ctlogKeys
 
-		// If keyless does not skip tlog verification, then default to rekor url as done in cosign
 		if authority.Keyless.SkipTlogVerify != nil {
 			ret.SkipTlogVerify = *authority.Keyless.SkipTlogVerify
-			if !*authority.Keyless.SkipTlogVerify {
-				rekorClient, err := rekor.GetRekorClient(DefaultRekorURL)
-				if err != nil {
-					logging.FromContext(ctx).Errorf("failed creating rekor client: %v", err)
-					return nil, fmt.Errorf("creating Rekor client: %w", err)
-				}
-				rekorPubKeys, err := cosign.GetRekorPubs(ctx)
-				if err != nil {
-					logging.FromContext(ctx).Errorf("failed getting rekor public keys: %v", err)
-					return nil, fmt.Errorf("getting Rekor public keys: %w", err)
-				}
-				ret.RekorClient = rekorClient
-				ret.RekorPubKeys = rekorPubKeys
+		}
+		// If keyless does not skip tlog verification, then default to rekor url as done in cosign
+		if authority.Keyless.SkipTlogVerify == nil || !*authority.Keyless.SkipTlogVerify {
+			rekorClient, err := rekor.GetRekorClient(DefaultRekorURL)
+			if err != nil {
+				logging.FromContext(ctx).Errorf("failed creating rekor client: %v", err)
+				return nil, fmt.Errorf("creating Rekor client: %w", err)
 			}
+			rekorPubKeys, err := cosign.GetRekorPubs(ctx)
+			if err != nil {
+				logging.FromContext(ctx).Errorf("failed getting rekor public keys: %v", err)
+				return nil, fmt.Errorf("getting Rekor public keys: %w", err)
+			}
+			ret.RekorClient = rekorClient
+			ret.RekorPubKeys = rekorPubKeys
 		}
 	}
+	// If a CTLog is specified then use these rekor settings instead of the rekor.sigstore.dev
 	if authority.CTLog != nil {
 		rekorClient, rekorPubKeys, err := rekorClientAndKeysFromAuthority(ctx, authority.CTLog)
 		if err != nil {

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -1298,11 +1298,11 @@ func checkOptsFromAuthority(ctx context.Context, authority webhookcip.Authority,
 		ret.IntermediateCerts = fulcioIntermediates
 		ret.CTLogPubKeys = ctlogKeys
 
-		if authority.Keyless.SkipTlogVerify != nil {
-			ret.SkipTlogVerify = *authority.Keyless.SkipTlogVerify
+		if authority.Keyless.IgnoreTlog != nil {
+			ret.SkipTlogVerify = *authority.Keyless.IgnoreTlog
 		}
 		// If keyless does not skip tlog verification, then default to rekor url as done in cosign
-		if authority.Keyless.SkipTlogVerify == nil || !*authority.Keyless.SkipTlogVerify {
+		if authority.Keyless.IgnoreTlog == nil || !*authority.Keyless.IgnoreTlog {
 			rekorClient, err := rekor.GetRekorClient(DefaultRekorURL)
 			if err != nil {
 				logging.FromContext(ctx).Errorf("failed creating rekor client: %v", err)
@@ -1330,6 +1330,10 @@ func checkOptsFromAuthority(ctx context.Context, authority webhookcip.Authority,
 	if ret.RekorClient == nil && ret.RekorPubKeys != nil {
 		// If there's keys however, use offline for verification.
 		ret.Offline = true
+	}
+	if ret.RekorClient == nil && ret.RekorPubKeys == nil {
+		// If there is not a rekor client definition then skip tlog verification.
+		ret.SkipTlogVerify = true
 	}
 
 	if authority.RFC3161Timestamp != nil && authority.RFC3161Timestamp.TrustRootRef != "" {

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -3173,8 +3173,10 @@ func TestCheckOptsFromAuthority(t *testing.T) {
 		name: "trustroot found, Fulcio",
 		authority: webhookcip.Authority{
 			Keyless: &webhookcip.KeylessRef{
-				URL:          apis.HTTPS("fulcio.example.com"),
-				TrustRootRef: "test-trust-fulcio"}},
+				URL:            apis.HTTPS("fulcio.example.com"),
+				TrustRootRef:   "test-trust-fulcio",
+				SkipTlogVerify: ptr.Bool(true),
+			}},
 		ctx: testCtx,
 		wantCheckOpts: &cosign.CheckOpts{
 			RootCerts:         roots,

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -3173,9 +3173,9 @@ func TestCheckOptsFromAuthority(t *testing.T) {
 		name: "trustroot found, Fulcio",
 		authority: webhookcip.Authority{
 			Keyless: &webhookcip.KeylessRef{
-				URL:            apis.HTTPS("fulcio.example.com"),
-				TrustRootRef:   "test-trust-fulcio",
-				SkipTlogVerify: ptr.Bool(true),
+				URL:          apis.HTTPS("fulcio.example.com"),
+				TrustRootRef: "test-trust-fulcio",
+				IgnoreTlog:   ptr.Bool(true),
 			}},
 		ctx: testCtx,
 		wantCheckOpts: &cosign.CheckOpts{

--- a/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
@@ -36,5 +36,4 @@ spec:
       identities:
       - issuerRegExp: .*kubernetes.default.*
         subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
-    ctlog:
-      url: http://rekor.sigstore.dev
+


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR aims to propose a solution for #479 by adding a new field that helps us handling all the different corner cases when deciding whether to skip the tlog verification or not. 

If a `spec.authority.ctlog.url` is not defined and `skipTlogVerify=false` for a keyless authority type, this code uses the default rekor url similarly to how the cosign library does it. Otherwise, if a `spec.authority.ctlog.url` is specified then it uses these rekor settings extracted from this ctlog.url instance.

There is some additional work to be done in this PR, I'm just waiting for early feedback at this point. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->