### PR TITLE
Fix keyless behauvior when ctlog is absent

### DIFF
--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -2994,7 +2994,7 @@ func TestRekorClientAndKeysFromAuthority(t *testing.T) {
 			if tCtx == nil {
 				tCtx = context.Background()
 			}
-			rekorClient, gotPKs, err := rekorClientAndKeysFromAuthority(tCtx, tc.tlog)
+			rekorClient, gotPKs, err := rekorClientAndKeysFromAuthority(tCtx, webhookcip.Authority{CTLog: tc.tlog})
 			if err != nil {
 				if tc.wantErr == "" {
 					t.Errorf("unexpected error: %v wanted none", err)

--- a/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-and-keyless.yaml
@@ -36,5 +36,4 @@ spec:
       identities:
       - issuerRegExp: .*kubernetes.default.*
         subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
-    ctlog:
-      url: http://rekor.sigstore.dev
+


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Whenever you define CIP a keyless authority without a ctlog or a trustRoot, the controller will assume you are verifying your images using the sigstore ctlog `rekor.sigstore.dev`. This PR supports the old legacy behavior of keyless verification while supporting TrustRoot references. 

```
apiVersion: policy.sigstore.dev/v1beta1
kind: ClusterImagePolicy
metadata:
  name: policy
spec:
  images:
    - glob: "**" # Your image here
  authorities:
    - name: keyatt
      keyless:
        url: "https://fulcio.sigstore.dev"
        identities:
        # Check the identity you expect to be signing SBOMs here!
        - issuerRegExp: ".*"
          subjectRegExp: ".*"
 ```
 
The controller fetches the RekorPublic keys while keeping the RekorClient nil which defaults to an offline behavior.

closes https://github.com/sigstore/policy-controller/issues/479

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->