### PR TITLE
only sub&rbac.

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -62,10 +62,10 @@ rules:
 
   # Allow reconciliation of the ClusterImagePolicy and TrustRoot CRDs.
   - apiGroups: ["policy.sigstore.dev"]
-    resources: ["clusterimagepolicies"]
+    resources: ["clusterimagepolicies", "clusterimagepolicies/status"]
     verbs: ["get", "list", "update", "watch", "patch"]
   - apiGroups: ["policy.sigstore.dev"]
-    resources: ["trustroots"]
+    resources: ["trustroots", "trustroots/status"]
     verbs: ["get", "list", "update", "watch", "patch"]
 
   # This is needed by k8schain to support fetching pull secrets attached to pod specs

--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -39,6 +39,8 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      subresources:
+        status: {}
       schema:
         openAPIV3Schema:
           type: object
@@ -328,6 +330,8 @@ spec:
     - name: v1beta1
       served: true
       storage: false
+      subresources:
+        status: {}
       schema:
         openAPIV3Schema:
           type: object

--- a/config/300-trustroot.yaml
+++ b/config/300-trustroot.yaml
@@ -31,6 +31,8 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      subresources:
+        status: {}
       schema:
         openAPIV3Schema:
           type: object


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Break away from the #533 only the subresource & rbac changes to make updates easier. This way we can roll out the changes more safe in the next release without having to spec out the order of updates. We'll do a fast follow with the code changes.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Add "status" as a subresource for CIP/Trustroot as well as the RBAC for the updates.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->