### PR TITLE
fix policy controller yaml filename and update release doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ GOFILES ?= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 # Set version variables for LDFLAGS
 PROJECT_ID ?= projectsigstore
 RUNTIME_IMAGE ?= gcr.io/distroless/static
-GIT_TAG ?= dirty-tag
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
 DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
@@ -56,7 +55,7 @@ GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
 KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)
 GHCR_PREFIX ?= ghcr.io/sigstore/policy-controller
-POLICY_CONTROLLER_YAML ?= policy-controller-$(GIT_TAG).yaml
+POLICY_CONTROLLER_YAML ?= policy-controller-$(GIT_VERSION).yaml
 LATEST_TAG ?=
 
 .PHONY: all lint test clean policy-controller cross docs

--- a/release/README.md
+++ b/release/README.md
@@ -1,8 +1,8 @@
 # Release
 
-This directory contain the files and scripts to run a cosign release.
+This directory contain the files and scripts to run a policy-controller release.
 
-# Cutting a Sigstore Release
+# Cutting a Policy Controller Release
 
 1. Release notes: Create a PR to update and review release notes in CHANGELOG.md.
   - Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
@@ -27,32 +27,7 @@ $ git tag -s ${RELEASE_TAG} -m "${RELEASE_TAG}"
 $ git push origin ${RELEASE_TAG}
 ```
 
-
-2. Submit the cloudbuild Job using the following command:
-
-```shell
-$ gcloud builds submit --config <PATH_TO_CLOUDBUILD> \
-   --substitutions _GIT_TAG=${RELEASE_TAG},_TOOL_ORG=sigstore,_TOOL_REPO=cosign,_STORAGE_LOCATION=cosign-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME>,_GITHUB_USER=<GITHUB_USER> \
-   --project <GCP_PROJECT>
-```
-
-Where:
-
-- `PATH_TO_CLOUDBUILD` is the path where the cloudbuild.yaml can be found.
-- `GCP_PROJECT` is the GCP project where we will run the job.
-- `_GIT_TAG` is the release version we are publishing.
-- `_TOOL_ORG` is the GitHub Org we will use. Default `sigstore`.
-- `_TOOL_REPO` is the repository we will use to clone. Default `cosign`.
-- `_STORAGE_LOCATION` where to push the built artifacts. Default `cosign-releases`.
-- `_KEY_RING` key ring name of your cosign key.
-- `_KEY_NAME` key name of your  cosign key.
-- `_KEY_VERSION` version of the key stored in KMS. Default `1`.
-- `_KEY_LOCATION` location in GCP where the key is stored. Default `global`.
-- `_GITHUB_USER` GitHub user to authenticate for pushing to GHCR.
-
-
-3. When the job finish, without issues, you should be able to see in GitHub a draft release.
-You now can review the release, make any changes if needed and then publish to make it an official release.
+3. The tag push will start the https://github.com/sigstore/policy-controller/blob/main/.github/workflows/release.yaml job and will build and release all the artifacts and images.
 
 4. Send an announcement email to `sigstore-dev@googlegroups.com` mailing list
 


### PR DESCRIPTION
#### Summary
- fix policy controller yaml filename and update release doc

the release was generating the filename as `policy-controller-dirty-tag.yaml` because the `GIT_TAG` is not set and we use `GIT_VERSION` instead 