### PR TITLE
test: enable testing two attestations

### DIFF
--- a/test/e2e_test_cluster_image_policy_with_attestations.sh
+++ b/test/e2e_test_cluster_image_policy_with_attestations.sh
@@ -224,11 +224,6 @@ else
 fi
 echo '::endgroup::'
 
-# We have to fix this bug, so bail for now so we get passing tests.
-# https://github.com/sigstore/policy-controller/issues/130
-echo "***********Exiting early due to bug 130*********"
-exit 0
-
 # So at this point, we have two CIP, one that requires keyless/key sig
 # and attestations with both. Let's take it up a notch.
 # Let's create a policy that requires both a keyless and keyful
@@ -265,6 +260,7 @@ if ! kubectl create -n ${NS} job demo3 --image=${demoimage} 2> ${KUBECTL_SUCCESS
   exit 1
 fi
 echo '::endgroup::'
+
 
 echo '::group::' Cleanup
 kubectl delete cip --all


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

related to: https://github.com/sigstore/policy-controller/issues/130#issuecomment-1408768856

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->