### PR TITLE
Add UT for fetching URL. Simplify SHA calc.

### DIFF
--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
@@ -163,7 +163,7 @@ func (r *Reconciler) handleCIPError(ctx context.Context, cipName string) {
 			logging.FromContext(ctx).Errorf("Failed to get configmap: %v", err)
 		}
 	} else if err := r.removeCIPEntry(ctx, existing, cipName); err != nil {
-		logging.FromContext(ctx).Errorf("Failed to get configmap: %v", err)
+		logging.FromContext(ctx).Errorf("Failed to remove CIP entry from configmap: %v", err)
 	}
 }
 
@@ -313,11 +313,10 @@ func (r *Reconciler) inlinePolicyURL(ctx context.Context, policyRef *v1alpha1.Po
 	if err != nil {
 		return fmt.Errorf("failed to read policy url response: %w", err)
 	}
-	// Chechking the sha256sum value in comparison with the one set in the policy
-	h := sha256.New()
-	_, _ = h.Write(data)
-	if fmt.Sprintf("%x", h.Sum(nil)) != policyRef.Remote.Sha256sum {
-		return fmt.Errorf("failed to check sha256sum from policy remote: %s", policyRef.Remote.Sha256sum)
+	// Checking the sha256sum value in comparison with the one set in the policy
+	sha256Sum := fmt.Sprintf("%x", sha256.Sum256(data))
+	if sha256Sum != policyRef.Remote.Sha256sum {
+		return fmt.Errorf("failed to check sha256sum from policy remote: %s got %s", policyRef.Remote.Sha256sum, sha256Sum)
 	}
 	policyRef.Data = string(data)
 	policyRef.Remote = nil


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Add UT for fetching policy from URL.
Also simplify the SHA computation inlining it. 
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->