### PR TITLE
fix policy conversion from v1beta1 to v1alpha1

### DIFF
--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
@@ -133,6 +133,9 @@ func (authority *Authority) ConvertTo(ctx context.Context, sink *v1beta1.Authori
 			sink.Keyless.CACert = &v1beta1.KeyRef{}
 			authority.Keyless.CACert.ConvertTo(ctx, sink.Keyless.CACert)
 		}
+		if authority.Keyless.InsecureIgnoreSCT != nil {
+			sink.Keyless.InsecureIgnoreSCT = authority.Keyless.InsecureIgnoreSCT
+		}
 	}
 	if authority.Static != nil {
 		sink.Static = &v1beta1.StaticRef{
@@ -282,6 +285,9 @@ func (authority *Authority) ConvertFrom(ctx context.Context, source *v1beta1.Aut
 		if source.Keyless.CACert != nil {
 			authority.Keyless.CACert = &KeyRef{}
 			authority.Keyless.CACert.ConvertFrom(ctx, source.Keyless.CACert)
+		}
+		if source.Keyless.InsecureIgnoreSCT != nil {
+			authority.Keyless.InsecureIgnoreSCT = source.Keyless.InsecureIgnoreSCT
 		}
 	}
 	if source.Static != nil {

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
@@ -291,6 +291,23 @@ func TestConversionRoundTripV1beta1(t *testing.T) {
 				},
 			},
 		},
+	}, {name: "key, keyless, and rfc3161timestamp, regexp",
+		in: &v1beta1.ClusterImagePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cip",
+			},
+			Spec: v1beta1.ClusterImagePolicySpec{
+				Images: []v1beta1.ImagePattern{{Glob: "*"}},
+				Authorities: []v1beta1.Authority{
+					{Keyless: &v1beta1.KeylessRef{
+						Identities:        []v1beta1.Identity{{SubjectRegExp: "subjectregexp", IssuerRegExp: "issuerregexp"}},
+						CACert:            &v1beta1.KeyRef{KMS: "kms", Data: "data", SecretRef: &v1.SecretReference{Name: "secret"}},
+						InsecureIgnoreSCT: ptr.Bool(true),
+					},
+					},
+				},
+			},
+		},
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
When testing keyless verifications, I found the ConfigMap was not populating the insecureSCT flag as part of a policy definition. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->