### PR TITLE
Only allow 1 source. Add tagPrefix field to source.

### DIFF
--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -216,7 +216,7 @@ spec:
                           type: object
                           properties:
                             oci:
-                              description: OCI defines the registry from where to pull the signatures.
+                              description: OCI defines the registry from where to pull the signature / attestations.
                               type: string
                             signaturePullSecrets:
                               description: SignaturePullSecrets is an optional list of references to secrets in the same namespace as the deploying resource for pulling any of the signatures used by this Source.
@@ -227,6 +227,9 @@ spec:
                                   name:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
+                            tagPrefix:
+                              description: TagPrefix is an optional prefix that signature and attestations have. This is the 'tag based discovery' and in the future once references are fully supported that should likely be the preferred way to handle these.
+                              type: string
                       static:
                         description: Static specifies that signatures / attestations are not validated but instead a static policy is applied against matching images.
                         type: object
@@ -546,7 +549,7 @@ spec:
                           type: object
                           properties:
                             oci:
-                              description: OCI defines the registry from where to pull the signatures.
+                              description: OCI defines the registry from where to pull the signature / attestations.
                               type: string
                             signaturePullSecrets:
                               description: SignaturePullSecrets is an optional list of references to secrets in the same namespace as the deploying resource for pulling any of the signatures used by this Source.
@@ -557,6 +560,9 @@ spec:
                                   name:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
+                            tagPrefix:
+                              description: TagPrefix is an optional prefix that signature and attestations have. This is the 'tag based discovery' and in the future once references are fully supported that should likely be the preferred way to handle these.
+                              type: string
                       static:
                         description: Static specifies that signatures / attestations are not validated but instead a static policy is applied against matching images.
                         type: object

--- a/docs/api-types/index-v1alpha1.md
+++ b/docs/api-types/index-v1alpha1.md
@@ -166,7 +166,7 @@ Attestation defines the type of attestation to validate and optionally apply a p
 | key | Key defines the type of key to validate the image. | [KeyRef](#keyref) | false |
 | keyless | Keyless sets the configuration to verify the authority against a Fulcio instance. | [KeylessRef](#keylessref) | false |
 | static | Static specifies that signatures / attestations are not validated but instead a static policy is applied against matching images. | [StaticRef](#staticref) | false |
-| source | Sources sets the configuration to specify the sources from where to consume the signatures. | [][Source](#source) | false |
+| source | Sources sets the configuration to specify the sources from where to consume the signature and attestations. | [][Source](#source) | false |
 | ctlog | CTLog sets the configuration to verify the authority against a Rekor instance. | [TLog](#tlog) | false |
 | attestations | Attestations is a list of individual attestations for this authority, once the signature for this authority has been verified. | [][Attestation](#attestation) | false |
 | rfc3161timestamp | RFC3161Timestamp sets the configuration to verify the signature timestamp against a RFC3161 time-stamping instance. | [RFC3161Timestamp](#rfc3161timestamp) | false |
@@ -327,12 +327,13 @@ RemotePolicy defines all the properties to fetch a remote policy
 
 ## Source
 
-Source specifies the location of the signature
+Source specifies the location of the signature / attestations.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| oci | OCI defines the registry from where to pull the signatures. | string | false |
+| oci | OCI defines the registry from where to pull the signature / attestations. | string | false |
 | signaturePullSecrets | SignaturePullSecrets is an optional list of references to secrets in the same namespace as the deploying resource for pulling any of the signatures used by this Source. | [][v1.LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#localobjectreference-v1-core) | false |
+| tagPrefix | TagPrefix is an optional prefix that signature and attestations have. This is the 'tag based discovery' and in the future once references are fully supported that should likely be the preferred way to handle these. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/api-types/index.md
+++ b/docs/api-types/index.md
@@ -206,12 +206,13 @@ RemotePolicy defines all the properties to fetch a remote policy
 
 ## Source
 
-Source specifies the location of the signature
+Source specifies the location of the signature / attestations.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| oci | OCI defines the registry from where to pull the signatures. | string | false |
+| oci | OCI defines the registry from where to pull the signature / attestations. | string | false |
 | signaturePullSecrets | SignaturePullSecrets is an optional list of references to secrets in the same namespace as the deploying resource for pulling any of the signatures used by this Source. | [][v1.LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#localobjectreference-v1-core) | false |
+| tagPrefix | TagPrefix is an optional prefix that signature and attestations have. This is the 'tag based discovery' and in the future once references are fully supported that should likely be the preferred way to handle these. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
@@ -102,6 +102,7 @@ func (authority *Authority) ConvertTo(ctx context.Context, sink *v1beta1.Authori
 	for _, source := range authority.Sources {
 		v1beta1Source := v1beta1.Source{}
 		v1beta1Source.OCI = source.OCI
+		v1beta1Source.TagPrefix = source.TagPrefix
 		for _, sps := range source.SignaturePullSecrets {
 			v1beta1Source.SignaturePullSecrets = append(v1beta1Source.SignaturePullSecrets, v1.LocalObjectReference{Name: sps.Name})
 		}
@@ -255,6 +256,7 @@ func (authority *Authority) ConvertFrom(ctx context.Context, source *v1beta1.Aut
 	for _, s := range source.Sources {
 		src := Source{}
 		src.OCI = s.OCI
+		src.TagPrefix = s.TagPrefix
 		for _, sps := range s.SignaturePullSecrets {
 			src.SignaturePullSecrets = append(src.SignaturePullSecrets, v1.LocalObjectReference{Name: sps.Name})
 		}

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
@@ -96,6 +96,7 @@ func TestConversionRoundTripV1alpha1(t *testing.T) {
 						SecretRef: &v1.SecretReference{Name: "mysecret"}}},
 					{Sources: []Source{{
 						OCI:                  "registry.example.com",
+						TagPrefix:            ptr.String("sbom"),
 						SignaturePullSecrets: []v1.LocalObjectReference{{Name: "sps-secret"}}}}},
 					{Attestations: []Attestation{{
 						Name:          "attestation-0",
@@ -272,7 +273,7 @@ func TestConversionRoundTripV1beta1(t *testing.T) {
 				},
 			},
 		},
-	}, {name: "key, keyless, and rfc3161timestamp, regexp",
+	}, {name: "key, keyless, source, and rfc3161timestamp, regexp",
 		in: &v1beta1.ClusterImagePolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-cip",
@@ -288,6 +289,10 @@ func TestConversionRoundTripV1beta1(t *testing.T) {
 					},
 						RFC3161Timestamp: &v1beta1.RFC3161Timestamp{TrustRootRef: "trust-root-tsa-ref"},
 					},
+					{Sources: []v1beta1.Source{{
+						OCI:                  "registry.example.com",
+						TagPrefix:            ptr.String("sbom"),
+						SignaturePullSecrets: []v1.LocalObjectReference{{Name: "sps-secret"}}}}},
 				},
 			},
 		},

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -131,7 +131,7 @@ type Authority struct {
 	// instead a static policy is applied against matching images.
 	// +optional
 	Static *StaticRef `json:"static,omitempty"`
-	// Sources sets the configuration to specify the sources from where to consume the signatures.
+	// Sources sets the configuration to specify the sources from where to consume the signature and attestations.
 	// +optional
 	Sources []Source `json:"source,omitempty"`
 	// CTLog sets the configuration to verify the authority against a Rekor instance.
@@ -172,9 +172,9 @@ type StaticRef struct {
 	Action string `json:"action"`
 }
 
-// Source specifies the location of the signature
+// Source specifies the location of the signature / attestations.
 type Source struct {
-	// OCI defines the registry from where to pull the signatures.
+	// OCI defines the registry from where to pull the signature / attestations.
 	// +optional
 	OCI string `json:"oci,omitempty"`
 	// SignaturePullSecrets is an optional list of references to secrets in the
@@ -182,6 +182,11 @@ type Source struct {
 	// used by this Source.
 	// +optional
 	SignaturePullSecrets []v1.LocalObjectReference `json:"signaturePullSecrets,omitempty"`
+	// TagPrefix is an optional prefix that signature and attestations have.
+	// This is the 'tag based discovery' and in the future once references are
+	// fully supported that should likely be the preferred way to handle these.
+	// +optional
+	TagPrefix *string `json:"tagPrefix,omitempty"`
 }
 
 // TLog specifies the URL to a transparency log that holds

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -130,8 +130,13 @@ func (authority *Authority) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	for i, source := range authority.Sources {
-		errs = errs.Also(source.Validate(ctx).ViaFieldIndex("source", i))
+	if len(authority.Sources) > 1 {
+		errs = errs.Also(apis.ErrInvalidValue("source", "source", "only single source is supported"))
+	} else {
+		// If there are multiple sources, don't complain about each of them.
+		for i, source := range authority.Sources {
+			errs = errs.Also(source.Validate(ctx).ViaFieldIndex("source", i))
+		}
 	}
 
 	for _, att := range authority.Attestations {

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -807,7 +807,22 @@ func TestAuthoritiesValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name: "Should pass with multiple source oci is present",
+		name: "Should pass with single source oci is present",
+		policy: ClusterImagePolicy{
+			Spec: ClusterImagePolicySpec{
+				Images: []ImagePattern{{Glob: "gcr.io/*"}},
+				Authorities: []Authority{
+					{
+						Key: &KeyRef{KMS: "hashivault://key/path"},
+						Sources: []Source{
+							{OCI: "registry1"},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name: "Should fail with multiple source oci is present",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{{Glob: "gcr.io/*"}},
@@ -822,6 +837,7 @@ func TestAuthoritiesValidation(t *testing.T) {
 				},
 			},
 		},
+		errorString: "invalid value: source: spec.authorities[0].source\nonly single source is supported",
 	}, {
 		name: "Should pass with attestations present",
 		policy: ClusterImagePolicy{

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -565,6 +565,11 @@ func (in *Source) DeepCopyInto(out *Source) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.TagPrefix != nil {
+		in, out := &in.TagPrefix, &out.TagPrefix
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -171,9 +171,9 @@ type StaticRef struct {
 	Action string `json:"action"`
 }
 
-// Source specifies the location of the signature
+// Source specifies the location of the signature / attestations.
 type Source struct {
-	// OCI defines the registry from where to pull the signatures.
+	// OCI defines the registry from where to pull the signature / attestations.
 	// +optional
 	OCI string `json:"oci,omitempty"`
 	// SignaturePullSecrets is an optional list of references to secrets in the
@@ -181,6 +181,11 @@ type Source struct {
 	// used by this Source.
 	// +optional
 	SignaturePullSecrets []v1.LocalObjectReference `json:"signaturePullSecrets,omitempty"`
+	// TagPrefix is an optional prefix that signature and attestations have.
+	// This is the 'tag based discovery' and in the future once references are
+	// fully supported that should likely be the preferred way to handle these.
+	// +optional
+	TagPrefix *string `json:"tagPrefix,omitempty"`
 }
 
 // TLog specifies the URL to a transparency log that holds

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -143,8 +143,13 @@ func (authority *Authority) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	for i, source := range authority.Sources {
-		errs = errs.Also(source.Validate(ctx).ViaFieldIndex("source", i))
+	if len(authority.Sources) > 1 {
+		errs = errs.Also(apis.ErrInvalidValue("source", "source", "only single source is supported"))
+	} else {
+		// If there are multiple sources, don't complain about each of them.
+		for i, source := range authority.Sources {
+			errs = errs.Also(source.Validate(ctx).ViaFieldIndex("source", i))
+		}
 	}
 
 	for _, att := range authority.Attestations {

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -796,12 +796,28 @@ func TestAuthoritiesValidation(t *testing.T) {
 						Key: &KeyRef{KMS: "hashivault://key/path"},
 						Sources: []Source{
 							{OCI: "registry1"},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name: "Should fail with multiple source oci is present",
+		policy: ClusterImagePolicy{
+			Spec: ClusterImagePolicySpec{
+				Images: []ImagePattern{{Glob: "gcr.io/*"}},
+				Authorities: []Authority{
+					{
+						Key: &KeyRef{KMS: "hashivault://key/path"},
+						Sources: []Source{
+							{OCI: "registry1"},
 							{OCI: "registry2"},
 						},
 					},
 				},
 			},
 		},
+		errorString: "invalid value: source: spec.authorities[0].source\nonly single source is supported",
 	}, {
 		name:        "Should fail with invalid AWS KMS for Keyful",
 		errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].key.kms\nkms key should be in the format awskms://[ENDPOINT]/[ID/ALIAS/ARN] (endpoint optional)",

--- a/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
@@ -434,6 +434,11 @@ func (in *Source) DeepCopyInto(out *Source) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.TagPrefix != nil {
+		in, out := &in.TagPrefix, &out.TagPrefix
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/webhook/clusterimagepolicy/clusterimagepolicy_types.go
+++ b/pkg/webhook/clusterimagepolicy/clusterimagepolicy_types.go
@@ -221,6 +221,10 @@ func (a *Authority) UnmarshalJSON(data []byte) error {
 					rawAuthority.RemoteOpts = append(rawAuthority.RemoteOpts, ociremote.WithTargetRepository(targetRepoOverride))
 				}
 			}
+			if source.TagPrefix != nil && *source.TagPrefix != "" {
+				rawAuthority.RemoteOpts = append(rawAuthority.RemoteOpts,
+					ociremote.WithPrefix(*source.TagPrefix))
+			}
 		}
 	}
 

--- a/test/e2e_test_cluster_image_policy_with_source.sh
+++ b/test/e2e_test_cluster_image_policy_with_source.sh
@@ -149,8 +149,8 @@ echo '::endgroup::'
 
 echo '::group:: Create an attestation without prefix, make sure it fails'
 echo -n 'foobar prefix e2e test' > ./predicate-file-prefix-custom
-cosign attest --predicate ./predicate-file-prefix-custom --rekor-url ${REKOR_URL} --key ./cosign.key --allow-insecure-registry --yes ${demoimage}
-cosign verify-attestation --allow-insecure-registry --rekor-url ${REKOR_URL} --certificate-identity-regexp='.*'  --certificate-oidc-issuer-regexp='.*' ${demoimage}
+cosign attest --predicate ./predicate-file-prefix-custom --rekor-url ${REKOR_URL} --allow-insecure-registry --yes ${demoimage} --fulcio-url ${FULCIO_URL} --identity-token ${OIDC_TOKEN}
+cosign verify-attestation --allow-insecure-registry --rekor-url ${REKOR_URL} --certificate-identity-regexp='.*' --certificate-oidc-issuer-regexp='.*' ${demoimage}
 echo '::endgroup::'
 
 echo '::group:: test job rejection using an OCI source to a wrong repository without signatures'
@@ -159,8 +159,8 @@ assert_error ${expected_error}
 echo '::endgroup::'
 
 echo '::group:: Create an attestation with prefix, make sure it fails'
-cosign attest --predicate ./predicate-file-prefix-custom --rekor-url ${REKOR_URL} --key ./cosign.key --allow-insecure-registry --yes ${demoimage} --attachment-tag-prefix=sigprefix
-cosign verify-attestation --allow-insecure-registry --rekor-url ${REKOR_URL} --certificate-identity-regexp='.*'  --certificate-oidc-issuer-regexp='.*' ${demoimage} --attachment-tag-prefix=sigprefix
+cosign attest --predicate ./predicate-file-prefix-custom --rekor-url ${REKOR_URL} --allow-insecure-registry --yes ${demoimage} --attachment-tag-prefix=sigprefix --fulcio-url ${FULCIO_URL} --identity-token ${OIDC_TOKEN}
+cosign verify-attestation --allow-insecure-registry --rekor-url ${REKOR_URL} --certificate-identity-regexp='.*' --certificate-oidc-issuer-regexp='.*' ${demoimage} --attachment-tag-prefix=sigprefix
 echo '::endgroup::'
 
 echo '::group:: test job success since we have attestation with prefix'

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-source-prefix-tag.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-source-prefix-tag.yaml
@@ -26,7 +26,15 @@ spec:
       - issuerRegExp: .*kubernetes.default.*
         subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     source:
-    # DO NOT CHECK THIS CHANGE IN.
-    - oci: registry.local:5001/policy-controller/demo
+    - prefixTag: sigprefix
     ctlog:
       url: http://rekor.rekor-system.svc
+    attestations:
+    - name: custom-match-predicate
+      predicateType: custom
+      policy:
+        type: cue
+        data: |
+          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicate: Data: "foobar prefix e2e test"
+

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-source-prefix-tag.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-source-prefix-tag.yaml
@@ -26,7 +26,7 @@ spec:
       - issuerRegExp: .*kubernetes.default.*
         subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     source:
-    - prefixTag: sigprefix
+    - tagPrefix: sigprefix
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-source.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-source.yaml
@@ -26,7 +26,6 @@ spec:
       - issuerRegExp: .*kubernetes.default.*
         subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     source:
-    # DO NOT CHECK THIS CHANGE IN.
-    - oci: registry.local:5001/policy-controller/demo
+    - oci: registry.local:5000/policy-controller/demo
     ctlog:
       url: http://rekor.rekor-system.svc


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fixes #577 
Fixes: #360 

As described in #360, last entry in the list wins, which is surprising and wrong. So, limit Source to only have 1 entry in the list for correctness.

Add source.tagPrefix field that allows one to get verify parity when signing and attesting with: `--attachment-tag-prefix` 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
Support tag-prefix for verifying signature / attestation.
**Breaking Change** You can only have 1 source specified for Authority.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->