### PR TITLE
Cleanup: Move where we restrict resource types.

### DIFF
--- a/cmd/policy_webhook/main.go
+++ b/cmd/policy_webhook/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/sharedmain"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/release-utils/version"
 
 	"github.com/sigstore/policy-controller/pkg/apis/policy"
+	"github.com/sigstore/policy-controller/pkg/apis/policy/common"
 	"github.com/sigstore/policy-controller/pkg/apis/policy/v1alpha1"
 	"github.com/sigstore/policy-controller/pkg/apis/policy/v1beta1"
 	"github.com/sigstore/policy-controller/pkg/config"
@@ -98,6 +100,11 @@ func main() {
 	} else {
 		ctx = clusterimagepolicy.ToContext(ctx, duration)
 	}
+
+	// This must match the set of resources we configure in
+	// cmd/webhook/main.go in the "types" map.
+	common.ValidResourceNames = sets.NewString("replicasets", "deployments",
+		"pods", "cronjobs", "jobs", "statefulsets", "daemonsets")
 
 	v := version.GetVersionInfo()
 	vJSON, _ := v.JSONString()

--- a/pkg/apis/policy/common/validation.go
+++ b/pkg/apis/policy/common/validation.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/kms/azure"
 	"github.com/sigstore/sigstore/pkg/signature/kms/gcp"
 	"github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 )
 
@@ -36,6 +37,22 @@ const (
 
 var (
 	SupportedKMSProviders = []string{aws.ReferenceScheme, azure.ReferenceScheme, hashivault.ReferenceScheme, gcp.ReferenceScheme}
+
+	// TODO: create constants in to cosign?
+	ValidPredicateTypes = sets.NewString("custom", "slsaprovenance", "spdx",
+		"spdxjson", "cyclonedx", "link", "vuln")
+
+	// If a static matches, define the behaviour for it.
+	ValidStaticRefTypes = sets.NewString("fail", "pass")
+
+	// Valid modes for a policy
+	ValidModes = sets.NewString("enforce", "warn")
+
+	// ValidResourceNames for a policy match selector.
+	// By default, this is empty, which should allow any resource name, however,
+	// this can be populated with the set of resources to allow in the validating
+	// webhook, which should match the set of resources.
+	ValidResourceNames = sets.NewString()
 )
 
 func ValidateOCI(oci string) error {

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -25,25 +25,10 @@ import (
 	"github.com/sigstore/policy-controller/pkg/apis/policy/common"
 	"github.com/sigstore/policy-controller/pkg/apis/signaturealgo"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/system"
 
 	policycontrollerconfig "github.com/sigstore/policy-controller/pkg/config"
-)
-
-var (
-	// TODO: create constants in to cosign?
-	validPredicateTypes = sets.NewString("custom", "slsaprovenance", "spdx", "spdxjson", "cyclonedx", "link", "vuln")
-
-	// If a static matches, define the behaviour for it.
-	validStaticRefTypes = sets.NewString("fail", "pass")
-
-	// Valid modes for a policy
-	validModes = sets.NewString("enforce", "warn")
-
-	// ValidResourceNames for a policy match selector
-	validResourceNames = sets.NewString("replicasets", "deployments", "pods", "cronjobs", "jobs", "statefulsets", "daemonsets")
 )
 
 // Validate implements apis.Validatable
@@ -71,7 +56,7 @@ func (spec *ClusterImagePolicySpec) Validate(ctx context.Context) (errors *apis.
 	for i, authority := range spec.Authorities {
 		errors = errors.Also(authority.Validate(ctx).ViaFieldIndex("authorities", i))
 	}
-	if spec.Mode != "" && !validModes.Has(spec.Mode) {
+	if spec.Mode != "" && !common.ValidModes.Has(spec.Mode) {
 		errors = errors.Also(apis.ErrInvalidValue(spec.Mode, "mode", "unsupported mode"))
 	}
 	for i, m := range spec.Match {
@@ -151,7 +136,7 @@ func (s *StaticRef) Validate(ctx context.Context) *apis.FieldError {
 
 	if s.Action == "" {
 		errs = errs.Also(apis.ErrMissingField("action"))
-	} else if !validStaticRefTypes.Has(s.Action) {
+	} else if !common.ValidStaticRefTypes.Has(s.Action) {
 		errs = errs.Also(apis.ErrInvalidValue(s.Action, "action", "unsupported action"))
 	}
 	return errs
@@ -159,7 +144,8 @@ func (s *StaticRef) Validate(ctx context.Context) *apis.FieldError {
 
 func (matchResource *MatchResource) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
-	if matchResource.Resource != "" && !validResourceNames.Has(matchResource.Resource) {
+	if matchResource.Resource != "" && common.ValidResourceNames.Len() > 0 &&
+		!common.ValidResourceNames.Has(matchResource.Resource) {
 		errs = errs.Also(apis.ErrInvalidValue(matchResource.Resource, "resource", "unsupported resource name"))
 	}
 
@@ -252,7 +238,7 @@ func (a *Attestation) Validate(ctx context.Context) *apis.FieldError {
 	}
 	if a.PredicateType == "" {
 		errs = errs.Also(apis.ErrMissingField("predicateType"))
-	} else if !validPredicateTypes.Has(a.PredicateType) {
+	} else if !common.ValidPredicateTypes.Has(a.PredicateType) {
 		// This could be a fully specified URL, so check for that here.
 		if _, err := url.ParseRequestURI(a.PredicateType); err != nil {
 			errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "unsupported predicate type"))

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sigstore/policy-controller/pkg/apis/policy/common"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1446,6 +1447,9 @@ func TestAWSKMSValidation(t *testing.T) {
 }
 
 func TestMatchValidation(t *testing.T) {
+	// Add a "supported" resource name that we'll use to test things.
+	common.ValidResourceNames.Insert("supported")
+
 	tests := []struct {
 		name        string
 		errorString string
@@ -1485,7 +1489,7 @@ func TestMatchValidation(t *testing.T) {
 						GroupVersionResource: metav1.GroupVersionResource{
 							Group:    "apps",
 							Version:  "v1",
-							Resource: "replicasets",
+							Resource: "supported",
 						},
 						ResourceSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"a": "b", "c": "d"},
@@ -1524,7 +1528,7 @@ func TestMatchValidation(t *testing.T) {
 						GroupVersionResource: metav1.GroupVersionResource{
 							Group:    "apps",
 							Version:  "v1",
-							Resource: "replicasets",
+							Resource: "supported",
 						},
 					},
 				},

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sigstore/policy-controller/pkg/apis/policy/common"
 	"github.com/sigstore/policy-controller/pkg/apis/signaturealgo"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -1556,6 +1557,9 @@ func validateError(t *testing.T, wantErrStr, wantWarnStr string, fe *apis.FieldE
 }
 
 func TestMatchValidation(t *testing.T) {
+	// Add a "supported" resource name that we'll use to test things.
+	common.ValidResourceNames.Insert("supported")
+
 	tests := []struct {
 		name        string
 		errorString string
@@ -1595,7 +1599,7 @@ func TestMatchValidation(t *testing.T) {
 						GroupVersionResource: metav1.GroupVersionResource{
 							Group:    "apps",
 							Version:  "v1",
-							Resource: "replicasets",
+							Resource: "supported",
 						},
 						ResourceSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"a": "b", "c": "d"},
@@ -1634,7 +1638,7 @@ func TestMatchValidation(t *testing.T) {
 						GroupVersionResource: metav1.GroupVersionResource{
 							Group:    "apps",
 							Version:  "v1",
-							Resource: "replicasets",
+							Resource: "supported",
 						},
 					},
 				},


### PR DESCRIPTION
:broom: This change moves a bunch of shared constants from `v1alpha1`/`v1beta1` into `common`

:broom: This also changes the behavior of `ValidResourceNames` slightly.  Rather than having the CIP validation bake in a fixed set of resources in the library (in a private variable), the binary entrypoint defines these close to where we set up the resource map, since these must be consistent!

/kind cleanup

#### Release Note

Enable the controller entrypoint to control the supported resource set validated in the webhook.

#### Documentation
