### PR TITLE
Deprecate short-names, and warn on non RFC3986 compliant predicate-types

### DIFF
--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -236,17 +236,19 @@ func (a *Attestation) Validate(ctx context.Context) *apis.FieldError {
 	if a.Name == "" {
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}
-	if a.PredicateType == "" {
+	switch {
+	case a.PredicateType == "":
+		// This is just straight up missing, so error out.
 		errs = errs.Also(apis.ErrMissingField("predicateType"))
-	} else if common.ValidPredicateTypes.Has(a.PredicateType) {
+	case common.ValidPredicateTypes.Has(a.PredicateType):
 		// Ok, it's a valid, deprecated short form. It's fine for now, but
-		// should remove it soon because it is very error prone.
+		// should remove it soon because it is very error prone, so warn.
 		errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "deprecated value, please use RFC 3986 conformant values").At(apis.WarningLevel))
-	} else if !common.ValidPredicateTypes.Has(a.PredicateType) {
+	default:
 		// This could be a fully specified URL, so check for that here.
 		if _, err := url.ParseRequestURI(a.PredicateType); err != nil {
-			// Ok, it's a valid, deprecated short form. It's fine for now, but
-			// should remove it soon because it is very error prone.
+			// This is fine for now, but should remove it soon because it is
+			// very error prone.
 			errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "deprecated value, please use RFC 3986 conformant values").At(apis.WarningLevel))
 		}
 	}

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -238,10 +238,16 @@ func (a *Attestation) Validate(ctx context.Context) *apis.FieldError {
 	}
 	if a.PredicateType == "" {
 		errs = errs.Also(apis.ErrMissingField("predicateType"))
+	} else if common.ValidPredicateTypes.Has(a.PredicateType) {
+		// Ok, it's a valid, deprecated short form. It's fine for now, but
+		// should remove it soon because it is very error prone.
+		errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "deprecated value, please use RFC 3986 conformant values").At(apis.WarningLevel))
 	} else if !common.ValidPredicateTypes.Has(a.PredicateType) {
 		// This could be a fully specified URL, so check for that here.
 		if _, err := url.ParseRequestURI(a.PredicateType); err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "unsupported predicate type"))
+			// Ok, it's a valid, deprecated short form. It's fine for now, but
+			// should remove it soon because it is very error prone.
+			errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "deprecated value, please use RFC 3986 conformant values").At(apis.WarningLevel))
 		}
 	}
 	errs = errs.Also(a.Policy.Validate(ctx).ViaField("policy"))

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -239,10 +239,16 @@ func (a *Attestation) Validate(ctx context.Context) *apis.FieldError {
 	}
 	if a.PredicateType == "" {
 		errs = errs.Also(apis.ErrMissingField("predicateType"))
+	} else if common.ValidPredicateTypes.Has(a.PredicateType) {
+		// Ok, it's a valid, deprecated short form. It's fine for now, but
+		// should remove it soon because it is very error prone.
+		errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "deprecated value, please use RFC 3986 conformant values").At(apis.WarningLevel))
 	} else if !common.ValidPredicateTypes.Has(a.PredicateType) {
 		// This could be a fully specified URL, so check for that here.
 		if _, err := url.ParseRequestURI(a.PredicateType); err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "unsupported predicate type"))
+			// Ok, it's a valid, deprecated short form. It's fine for now, but
+			// should remove it soon because it is very error prone.
+			errs = errs.Also(apis.ErrInvalidValue(a.PredicateType, "predicateType", "deprecated value, please use RFC 3986 conformant values").At(apis.WarningLevel))
 		}
 	}
 	errs = errs.Also(a.Policy.Validate(ctx).ViaField("policy"))

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -604,6 +604,7 @@ func TestAuthoritiesValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
+		warnString  string
 		policy      ClusterImagePolicy
 	}{{
 		name:        "Should fail when authority is empty",
@@ -694,8 +695,9 @@ func TestAuthoritiesValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name:        "Should fail when static and sources,attestations, and ctlog is specified",
+		name:        "Should fail when static and sources,attestations, and ctlog is specified, warn about legacy short predicate type",
 		errorString: "expected exactly one, got both: spec.authorities[0].attestations, spec.authorities[0].ctlog, spec.authorities[0].source, spec.authorities[0].static",
+		warnString:  "invalid value: vuln: spec.authorities[0].attestations.predicateType\ndeprecated value, please use RFC 3986 conformant values",
 		policy: ClusterImagePolicy{
 			Spec: ClusterImagePolicySpec{
 				Images: []ImagePattern{
@@ -747,7 +749,7 @@ func TestAuthoritiesValidation(t *testing.T) {
 				Authorities: []Authority{
 					{
 						Static:       &StaticRef{Action: "fail"},
-						Attestations: []Attestation{{Name: "first", PredicateType: "vuln"}},
+						Attestations: []Attestation{{Name: "first", PredicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"}},
 						Sources: []Source{
 							{
 								OCI: "registry1",
@@ -855,8 +857,8 @@ func TestAuthoritiesValidation(t *testing.T) {
 					{
 						Key: &KeyRef{KMS: "hashivault://key/path"},
 						Attestations: []Attestation{
-							{Name: "first", PredicateType: "vuln"},
-							{Name: "second", PredicateType: "custom", Policy: &Policy{
+							{Name: "first", PredicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"},
+							{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1", Policy: &Policy{
 								Type: "cue",
 								Data: `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
 							},
@@ -875,8 +877,8 @@ func TestAuthoritiesValidation(t *testing.T) {
 					{
 						Key: &KeyRef{KMS: "hashivault://key/path"},
 						Attestations: []Attestation{
-							{Name: "first", PredicateType: "vuln"},
-							{Name: "second", PredicateType: "custom", Policy: &Policy{
+							{Name: "first", PredicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"},
+							{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1", Policy: &Policy{
 								Type:            "cue",
 								Data:            `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
 								FetchConfigFile: ptr.Bool(true),
@@ -897,8 +899,8 @@ func TestAuthoritiesValidation(t *testing.T) {
 					{
 						Key: &KeyRef{KMS: "hashivault://key/path"},
 						Attestations: []Attestation{
-							{Name: "first", PredicateType: "vuln"},
-							{Name: "second", PredicateType: "custom", Policy: &Policy{
+							{Name: "first", PredicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"},
+							{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1", Policy: &Policy{
 								Type:        "cue",
 								Data:        `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
 								IncludeSpec: ptr.Bool(true),
@@ -919,8 +921,8 @@ func TestAuthoritiesValidation(t *testing.T) {
 					{
 						Key: &KeyRef{KMS: "hashivault://key/path"},
 						Attestations: []Attestation{
-							{Name: "first", PredicateType: "vuln"},
-							{Name: "second", PredicateType: "custom", Policy: &Policy{
+							{Name: "first", PredicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"},
+							{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1", Policy: &Policy{
 								Type:              "cue",
 								Data:              `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
 								IncludeObjectMeta: ptr.Bool(true),
@@ -941,8 +943,8 @@ func TestAuthoritiesValidation(t *testing.T) {
 					{
 						Key: &KeyRef{KMS: "hashivault://key/path"},
 						Attestations: []Attestation{
-							{Name: "first", PredicateType: "vuln"},
-							{Name: "second", PredicateType: "custom", Policy: &Policy{
+							{Name: "first", PredicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"},
+							{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1", Policy: &Policy{
 								Type:            "cue",
 								Data:            `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
 								IncludeTypeMeta: ptr.Bool(true),
@@ -1069,7 +1071,7 @@ func TestAuthoritiesValidation(t *testing.T) {
 			testContext := policycontrollerconfig.ToContext(context.TODO(), &policycontrollerconfig.PolicyControllerConfig{NoMatchPolicy: policycontrollerconfig.AllowAll, FailOnEmptyAuthorities: true})
 
 			err := test.policy.Validate(testContext)
-			validateError(t, test.errorString, "", err)
+			validateError(t, test.errorString, test.warnString, err)
 		})
 	}
 }
@@ -1104,16 +1106,17 @@ func TestAttestationsValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		errorString string
+		warnString  string
 		attestation Attestation
 	}{{
-		name:        "vuln",
-		attestation: Attestation{Name: "first", PredicateType: "vuln"},
+		name:        "https://cosign.sigstore.dev/attestation/vuln/v1",
+		attestation: Attestation{Name: "first", PredicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"},
 	}, {
 		name:        "fully specified URL",
 		attestation: Attestation{Name: "fullyspecified", PredicateType: "https://cyclonedx.org/schema"},
 	}, {
 		name:        "missing name",
-		attestation: Attestation{PredicateType: "vuln"},
+		attestation: Attestation{PredicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"},
 		errorString: "missing field(s): name",
 	}, {
 		name:        "missing predicatetype",
@@ -1122,10 +1125,10 @@ func TestAttestationsValidation(t *testing.T) {
 	}, {
 		name:        "invalid predicatetype",
 		attestation: Attestation{Name: "first", PredicateType: "notsupported"},
-		errorString: "invalid value: notsupported: predicateType\nunsupported predicate type",
+		warnString:  "invalid value: notsupported: predicateType\ndeprecated value, please use RFC 3986 conformant values",
 	}, {
 		name: "custom with invalid policy type",
-		attestation: Attestation{Name: "second", PredicateType: "custom",
+		attestation: Attestation{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1",
 			Policy: &Policy{
 				Type: "not-cue",
 				Data: `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
@@ -1134,7 +1137,7 @@ func TestAttestationsValidation(t *testing.T) {
 		errorString: "invalid value: not-cue: policy.type\nonly [cue,rego] are supported at the moment",
 	}, {
 		name: "custom with missing policy data, url and configMapRef",
-		attestation: Attestation{Name: "second", PredicateType: "custom",
+		attestation: Attestation{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1",
 			Policy: &Policy{
 				Type: "cue",
 			},
@@ -1142,7 +1145,7 @@ func TestAttestationsValidation(t *testing.T) {
 		errorString: "missing field(s): policy.configMapRef, policy.data, policy.remote",
 	}, {
 		name: "custom with both policy data and configMapRef",
-		attestation: Attestation{Name: "second", PredicateType: "custom",
+		attestation: Attestation{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1",
 			Policy: &Policy{
 				Type: "cue",
 				Data: `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
@@ -1155,7 +1158,7 @@ func TestAttestationsValidation(t *testing.T) {
 		errorString: "expected exactly one, got both: policy.configMapRef, policy.data, policy.remote",
 	}, {
 		name: "custom with both policy data, url and configMapRef",
-		attestation: Attestation{Name: "second", PredicateType: "custom",
+		attestation: Attestation{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1",
 			Policy: &Policy{
 				Type: "cue",
 				Data: `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
@@ -1172,7 +1175,7 @@ func TestAttestationsValidation(t *testing.T) {
 		errorString: "expected exactly one, got both: policy.configMapRef, policy.data, policy.remote",
 	}, {
 		name: "custom with both policy url",
-		attestation: Attestation{Name: "second", PredicateType: "custom",
+		attestation: Attestation{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1",
 			Policy: &Policy{
 				Type: "cue",
 				Remote: &RemotePolicy{
@@ -1183,7 +1186,7 @@ func TestAttestationsValidation(t *testing.T) {
 		},
 	}, {
 		name: "custom with invalid policy url scheme",
-		attestation: Attestation{Name: "second", PredicateType: "custom",
+		attestation: Attestation{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1",
 			Policy: &Policy{
 				Type: "cue",
 				Remote: &RemotePolicy{
@@ -1195,7 +1198,7 @@ func TestAttestationsValidation(t *testing.T) {
 		errorString: "invalid value: http://example.com: policy.remote.url\nurl valid is invalid. host and https scheme are expected",
 	}, {
 		name: "custom with invalid configMapRef, missing key",
-		attestation: Attestation{Name: "second", PredicateType: "custom",
+		attestation: Attestation{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1",
 			Policy: &Policy{
 				Type: "cue",
 				ConfigMapRef: &ConfigMapReference{
@@ -1206,7 +1209,7 @@ func TestAttestationsValidation(t *testing.T) {
 		errorString: "missing field(s): policy.configMapRef.key",
 	}, {
 		name: "custom with policy",
-		attestation: Attestation{Name: "second", PredicateType: "custom",
+		attestation: Attestation{Name: "second", PredicateType: "https://cosign.sigstore.dev/attestation/v1",
 			Policy: &Policy{
 				Type: "cue",
 				Data: `predicateType: "cosign.sigstore.dev/attestation/vuln/v1"`,
@@ -1218,7 +1221,7 @@ func TestAttestationsValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.attestation.Validate(context.TODO())
-			validateError(t, test.errorString, "", err)
+			validateError(t, test.errorString, test.warnString, err)
 		})
 	}
 }

--- a/test/testdata/policies/cue-vuln-fails.cue
+++ b/test/testdata/policies/cue-vuln-fails.cue
@@ -5,7 +5,7 @@ before: time.Parse(time.RFC3339, "2022-04-01T17:10:27Z")
 after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
 
 // The predicateType field must match this string
-predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
 
 predicate: {
   invocation: {

--- a/test/testdata/policies/cue-vuln-works.cue
+++ b/test/testdata/policies/cue-vuln-works.cue
@@ -4,7 +4,7 @@ before: time.Parse(time.RFC3339, "2022-04-15T17:10:27Z")
 after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
 
 // The predicateType field must match this string
-predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
 
 predicate: {
   invocation: {

--- a/test/testdata/policies/cue-works.cue
+++ b/test/testdata/policies/cue-works.cue
@@ -3,7 +3,7 @@ import "time"
 before: time.Parse(time.RFC3339, "2049-10-09T17:10:27Z")
 
 // The predicateType field must match this string
-predicateType: "cosign.sigstore.dev/attestation/v1"
+predicateType: "https://cosign.sigstore.dev/attestation/v1"
 
 // The predicate must match the following constraints.
 predicate: {

--- a/test/testdata/policy-controller/e2e/cip-key-with-attestations-no-rekor.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-with-attestations-no-rekor.yaml
@@ -29,7 +29,7 @@ spec:
         -----END PUBLIC KEY-----
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-key-with-attestations-rego.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-with-attestations-rego.yaml
@@ -31,7 +31,7 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-key-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-key-with-attestations.yaml
@@ -31,7 +31,7 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-attestations-rego.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-attestations-rego.yaml
@@ -30,7 +30,7 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: rego
         data: |

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-attestations.yaml
@@ -30,7 +30,7 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-source-prefix-tag.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-source-prefix-tag.yaml
@@ -31,7 +31,7 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-remote-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-remote-with-attestations.yaml
@@ -32,7 +32,7 @@ spec:
       trustRootRef: my-remote
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-repository-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-repository-with-attestations.yaml
@@ -32,7 +32,7 @@ spec:
       trustRootRef: my-repository-serialized
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-with-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-trustroot-with-attestations.yaml
@@ -32,7 +32,7 @@ spec:
       trustRootRef: my-sigstore-keys
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations-rego.yaml
+++ b/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations-rego.yaml
@@ -29,7 +29,7 @@ spec:
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:
-    - predicateType: custom
+    - predicateType: "https://cosign.sigstore.dev/attestation/v1"
       name: customkeyless
       policy:
         type: cue
@@ -41,7 +41,7 @@ spec:
             Data: "foobar e2e test"
             Timestamp: <before
           }
-    - predicateType: vuln
+    - predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
       name: vulnkeyless
       policy:
         type: cue
@@ -75,7 +75,7 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml
+++ b/test/testdata/policy-controller/e2e/cip-requires-two-signatures-and-two-attestations.yaml
@@ -29,7 +29,7 @@ spec:
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:
-    - predicateType: custom
+    - predicateType: "https://cosign.sigstore.dev/attestation/v1"
       name: customkeyless
       policy:
         type: cue
@@ -41,7 +41,7 @@ spec:
             Data: "foobar e2e test"
             Timestamp: <before
           }
-    - predicateType: vuln
+    - predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
       name: vulnkeyless
       policy:
         type: cue
@@ -75,7 +75,7 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |

--- a/test/testdata/policy-controller/valid/v1beta1-valid-policy.yaml
+++ b/test/testdata/policy-controller/valid/v1beta1-valid-policy.yaml
@@ -40,25 +40,25 @@ spec:
         subject: "subject-details"
     attestations:
     - name: custom-predicate-type-validation
-      predicateType: custom
+      predicateType: https://cosign.sigstore.dev/attestation/v1
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2049-10-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/v1"
           predicate: {
             Timestamp: <before
           }
     - name: vuln-predicate-type-validation
-      predicateType: vuln
+      predicateType: https://cosign.sigstore.dev/attestation/vuln/v1
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2022-04-15T17:10:27Z")
           after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
           predicate: {
             invocation: {
               uri: "invocation.example.com/cosign-testing"

--- a/test/testdata/policy-controller/valid/valid-policy-hash-algo.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy-hash-algo.yaml
@@ -42,25 +42,25 @@ spec:
         subject: "subject-details"
     attestations:
     - name: custom-predicate-type-validation
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2049-10-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/v1"
           predicate: {
             Timestamp: <before
           }
     - name: vuln-predicate-type-validation
-      predicateType: vuln
+      predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2022-04-15T17:10:27Z")
           after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
           predicate: {
             invocation: {
               uri: "invocation.example.com/cosign-testing"

--- a/test/testdata/policy-controller/valid/valid-policy-match-resource-label.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy-match-resource-label.yaml
@@ -48,25 +48,25 @@ spec:
         subject: "subject-details"
     attestations:
     - name: custom-predicate-type-validation
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2049-10-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/v1"
           predicate: {
             Timestamp: <before
           }
     - name: vuln-predicate-type-validation
-      predicateType: vuln
+      predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2022-04-15T17:10:27Z")
           after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
           predicate: {
             invocation: {
               uri: "invocation.example.com/cosign-testing"

--- a/test/testdata/policy-controller/valid/valid-policy-match-resource.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy-match-resource.yaml
@@ -46,25 +46,25 @@ spec:
         subject: "subject-details"
     attestations:
     - name: custom-predicate-type-validation
-      predicateType: custom
+      predicateType: "https://cosign.sigstore.dev/attestation/v1"
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2049-10-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/v1"
           predicate: {
             Timestamp: <before
           }
     - name: vuln-predicate-type-validation
-      predicateType: vuln
+      predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2022-04-15T17:10:27Z")
           after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
           predicate: {
             invocation: {
               uri: "invocation.example.com/cosign-testing"

--- a/test/testdata/policy-controller/valid/valid-policy.yaml
+++ b/test/testdata/policy-controller/valid/valid-policy.yaml
@@ -42,25 +42,25 @@ spec:
         subject: "subject-details"
     attestations:
     - name: custom-predicate-type-validation
-      predicateType: custom
+      predicateType: https://cosign.sigstore.dev/attestation/v1
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2049-10-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/v1"
           predicate: {
             Timestamp: <before
           }
     - name: vuln-predicate-type-validation
-      predicateType: vuln
+      predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2022-04-15T17:10:27Z")
           after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
           predicate: {
             invocation: {
               uri: "invocation.example.com/cosign-testing"


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fixes: #608
Fixes: #609 

Deprecate and start warning on short-names for the predicateTypes.
Also warn for non RFC3986 predicateTypes.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
Deprecate and start warning on short-names for the predicateTypes (things like 'vuln', 'custom')
Warn for non RFC3986 predicateTypes. These we will have to live with for a while :)

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
* We will have to go through our public documentation and make sure all the examples are correct.
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->