### PR TITLE
Pass ctx to fix build

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -1386,11 +1386,11 @@ func sigstoreKeysFromContext(ctx context.Context, trustRootRef string) (*config.
 func fulcioCertsFromAuthority(ctx context.Context, keylessRef *webhookcip.KeylessRef) (*x509.CertPool, *x509.CertPool, *cosign.TrustedTransparencyLogPubKeys, error) {
 	// If this is not Keyless, there's no Fulcio, so just return
 	if keylessRef.TrustRootRef == "" {
-		roots, err := fulcioroots.Get()
+		roots, err := fulcioroots.Get(ctx)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to fetch Fulcio roots: %w", err)
 		}
-		intermediates, err := fulcioroots.GetIntermediates()
+		intermediates, err := fulcioroots.GetIntermediates(ctx)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to fetch Fulcio intermediates: %w", err)
 		}


### PR DESCRIPTION
#### Summary

```
# github.com/sigstore/policy-controller/pkg/webhook
pkg/webhook/validator.go:1389:17: not enough arguments in call to fulcioroots.Get
	have ()
	want ("context".Context)
pkg/webhook/validator.go:1393:25: not enough arguments in call to fulcioroots.GetIntermediates
	have ()
	want ("context".Context)
```

#### Release Note

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
