### PR TITLE
fix: broken release pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@
 bin*
 dist/
 policyControllerImagerefs
-policyImagerefs
 
 **verify-experimental*
 

--- a/release/ko-sign-release-images.sh
+++ b/release/ko-sign-release-images.sh
@@ -26,11 +26,5 @@ if [[ ! -f policyControllerImagerefs ]]; then
     exit 1
 fi
 
-if [[ ! -f policyImagerefs ]]; then
-    echo "policyImagerefs not found"
-    exit 1
-fi
-
 echo "Signing images with Keyless..."
 cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat policyControllerImagerefs)
-cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat policyImagerefs)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

The release pipeline was broken https://github.com/sigstore/policy-controller/actions/runs/5321425956/jobs/9636506755.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
fix: broken release pipeline expecting one more controller image to sign.
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
