### PR TITLE
Use v0.7.18 for scaffolding, update k8s versions to test with.

### DIFF
--- a/.github/workflows/kind-cluster-image-policy-no-tuf.yaml
+++ b/.github/workflows/kind-cluster-image-policy-no-tuf.yaml
@@ -40,7 +40,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.17"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-no-tuf.yaml
+++ b/.github/workflows/kind-cluster-image-policy-no-tuf.yaml
@@ -33,13 +33,14 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.27.x
-        - v1.28.x
         - v1.29.x
+        - v1.30.x
+        - v1.31.x
+        - v1.32.x
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.2"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-no-tuf.yaml
+++ b/.github/workflows/kind-cluster-image-policy-no-tuf.yaml
@@ -40,7 +40,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.17"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-trustroot.yaml
+++ b/.github/workflows/kind-cluster-image-policy-trustroot.yaml
@@ -33,9 +33,10 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.27.x
-          - v1.28.x
           - v1.29.x
+          - v1.30.x
+          - v1.31.x
+          - v1.32.x
 
         script:
         - repository
@@ -44,7 +45,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.2"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-trustroot.yaml
+++ b/.github/workflows/kind-cluster-image-policy-trustroot.yaml
@@ -45,7 +45,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.17"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-trustroot.yaml
+++ b/.github/workflows/kind-cluster-image-policy-trustroot.yaml
@@ -45,7 +45,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.17"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-tsa.yaml
+++ b/.github/workflows/kind-cluster-image-policy-tsa.yaml
@@ -40,7 +40,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.17"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-tsa.yaml
+++ b/.github/workflows/kind-cluster-image-policy-tsa.yaml
@@ -40,7 +40,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.17"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy-tsa.yaml
+++ b/.github/workflows/kind-cluster-image-policy-tsa.yaml
@@ -33,13 +33,14 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.27.x
-          - v1.28.x
           - v1.29.x
+          - v1.30.x
+          - v1.31.x
+          - v1.32.x
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.2"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -54,7 +54,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.17"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -33,9 +33,10 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.27.x
-          - v1.28.x
           - v1.29.x
+          - v1.30.x
+          - v1.31.x
+          - v1.32.x
 
         script:
         - cluster_image_policy
@@ -53,7 +54,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.2"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -54,7 +54,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.7.17"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.18"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Remove old versions of k8s since they are no longer supported, we should not be testing with them.
Use new scaffolding version that support later versions of k8s.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
