### PR TITLE
Preserve original tag when resolving an image tag to digest

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -1078,7 +1078,12 @@ func (v *Validator) resolvePodSpec(ctx context.Context, ps *corev1.PodSpec, opt 
 					logging.FromContext(ctx).Debugf("Unable to resolve digest %q: %v", ref.String(), err)
 					continue
 				}
-				cs[i].Image = digest.String()
+				// Keep the original tag and append the digest
+				if tagRef, ok := ref.(name.Tag); ok {
+					cs[i].Image = fmt.Sprintf("%s@%s", tagRef.Name(), digest.DigestStr())
+				} else {
+					cs[i].Image = digest.String()
+				}
 			}
 		}
 	}
@@ -1102,7 +1107,12 @@ func (v *Validator) resolvePodSpec(ctx context.Context, ps *corev1.PodSpec, opt 
 					logging.FromContext(ctx).Debugf("Unable to resolve digest %q: %v", ref.String(), err)
 					continue
 				}
-				cs[i].Image = digest.String()
+				// Keep the original tag and append the digest
+				if tagRef, ok := ref.(name.Tag); ok {
+					cs[i].Image = fmt.Sprintf("%s@%s", tagRef.Name(), digest.DigestStr())
+				} else {
+					cs[i].Image = digest.String()
+				}
 			}
 		}
 	}

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -136,9 +136,6 @@ func TestValidatePodSpec(t *testing.T) {
 	// Resolved via crane digest on 2022/09/29
 	digestNewer := name.MustParseReference("gcr.io/distroless/static:nonroot@sha256:2a9e2b4fa771d31fe3346a873be845bfc2159695b9f90ca08e950497006ccc2e")
 
-	// Digest only reference (without tag)
-	digestOnly := name.MustParseReference("gcr.io/distroless/static@sha256:be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4")
-
 	ctx, _ := rtesting.SetupFakeContext(t)
 
 	// Non-existent URL for testing complete failure
@@ -684,38 +681,6 @@ func TestValidatePodSpec(t *testing.T) {
 			},
 		),
 		cvs: authorityPublicKeyCVS,
-	}, {
-		name: "digest only",
-		ps: &corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "user-container",
-				Image: digestOnly.String(),
-			}},
-		},
-		customContext: config.ToContext(context.Background(),
-			&config.Config{
-				ImagePolicyConfig: &config.ImagePolicyConfig{
-					Policies: map[string]webhookcip.ClusterImagePolicy{
-						"cluster-image-policy": {
-							Images: []v1alpha1.ImagePattern{{
-								Glob: "gcr.io/*/*",
-							}},
-							Authorities: []webhookcip.Authority{
-								{
-									Key: &webhookcip.KeyRef{
-										Data:              authorityKeyCosignPubString,
-										PublicKeys:        []crypto.PublicKey{authorityKeyCosignPub},
-										HashAlgorithm:     signaturealgo.DefaultSignatureAlgorithm,
-										HashAlgorithmCode: crypto.SHA256,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		),
-		cvs: pass,
 	}}
 
 	for _, test := range tests {

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -136,6 +136,9 @@ func TestValidatePodSpec(t *testing.T) {
 	// Resolved via crane digest on 2022/09/29
 	digestNewer := name.MustParseReference("gcr.io/distroless/static:nonroot@sha256:2a9e2b4fa771d31fe3346a873be845bfc2159695b9f90ca08e950497006ccc2e")
 
+	// Digest only reference (without tag)
+	digestOnly := name.MustParseReference("gcr.io/distroless/static@sha256:be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4")
+
 	ctx, _ := rtesting.SetupFakeContext(t)
 
 	// Non-existent URL for testing complete failure
@@ -681,6 +684,38 @@ func TestValidatePodSpec(t *testing.T) {
 			},
 		),
 		cvs: authorityPublicKeyCVS,
+	}, {
+		name: "digest only",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digestOnly.String(),
+			}},
+		},
+		customContext: config.ToContext(context.Background(),
+			&config.Config{
+				ImagePolicyConfig: &config.ImagePolicyConfig{
+					Policies: map[string]webhookcip.ClusterImagePolicy{
+						"cluster-image-policy": {
+							Images: []v1alpha1.ImagePattern{{
+								Glob: "gcr.io/*/*",
+							}},
+							Authorities: []webhookcip.Authority{
+								{
+									Key: &webhookcip.KeyRef{
+										Data:              authorityKeyCosignPubString,
+										PublicKeys:        []crypto.PublicKey{authorityKeyCosignPub},
+										HashAlgorithm:     signaturealgo.DefaultSignatureAlgorithm,
+										HashAlgorithmCode: crypto.SHA256,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+		cvs: pass,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR updates the code to preserve the original image tag when resolving image tags to digests in the mutating webhook.

Currently, the Sigstore Policy Controller's mutating webhook converts image references from `{registry}/{repository}:{tag}` to `{registry}/{repository}@sha256:{hash}`. This PR changes the behavior to convert them to `{registry}/{repository}:{tag}@sha256:{hash}` instead.

This change is considered to have no security concerns because when both a tag and a digest are specified for an image, the tag is ignored, and only the digest is used for image pulling and verification by container runtimes.

Preserving the image tag offers benefits such as:

* **Improved human readability:** Makes it easier to quickly identify which image version is being used.
* **Enhanced observability:** Useful for collecting service metrics based on image tags.

Closes https://github.com/sigstore/policy-controller/issues/1681

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
