### PR TITLE
Add OCI 1.1 referrers API support for attestation discovery

### DIFF
--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -41,6 +41,7 @@ jobs:
         script:
         - cluster_image_policy
         - cluster_image_policy_with_attestations
+        - cluster_image_policy_with_oci11_attestations
         - cluster_with_scalable
         - cluster_image_policy_with_warn
         - cluster_image_policy_with_source

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -43,6 +43,8 @@ const (
 	NoMatchPolicyKey = "no-match-policy"
 
 	FailOnEmptyAuthorities = "fail-on-empty-authorities"
+
+	EnableOCI11 = "enable-oci11"
 )
 
 // PolicyControllerConfig controls the behaviour of policy-controller that needs
@@ -56,6 +58,8 @@ type PolicyControllerConfig struct {
 	NoMatchPolicy string `json:"no-match-policy"`
 	// FailOnEmptyAuthorities configures the validating webhook to allow creating CIP without a list authorities
 	FailOnEmptyAuthorities bool `json:"fail-on-empty-authorities"`
+	// EnableOCI11 enables experimental OCI 1.1 referrers API for attestation discovery
+	EnableOCI11 bool `json:"enable-oci11"`
 }
 
 func NewPolicyControllerConfigFromMap(data map[string]string) (*PolicyControllerConfig, error) {
@@ -73,9 +77,17 @@ func NewPolicyControllerConfigFromMap(data map[string]string) (*PolicyController
 	if val, ok := data[FailOnEmptyAuthorities]; ok {
 		var err error
 		ret.FailOnEmptyAuthorities, err = strconv.ParseBool(val)
-		return ret, err
+		if err != nil {
+			return ret, err
+		}
 	}
-	ret.FailOnEmptyAuthorities = true
+	if val, ok := data[EnableOCI11]; ok {
+		var err error
+		ret.EnableOCI11, err = strconv.ParseBool(val)
+		if err != nil {
+			return ret, err
+		}
+	}
 	return ret, nil
 }
 
@@ -102,6 +114,7 @@ func FromContextOrDefaults(ctx context.Context) *PolicyControllerConfig {
 	return &PolicyControllerConfig{
 		NoMatchPolicy:          DenyAll,
 		FailOnEmptyAuthorities: true,
+		EnableOCI11:            false,
 	}
 }
 

--- a/pkg/config/testdata/enable-oci11-invalid.yaml
+++ b/pkg/config/testdata/enable-oci11-invalid.yaml
@@ -1,0 +1,22 @@
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-policy-controller
+  namespace: cosign-system
+data:
+  enable-oci11: "not-a-boolean"
+

--- a/pkg/config/testdata/enable-oci11.yaml
+++ b/pkg/config/testdata/enable-oci11.yaml
@@ -1,0 +1,22 @@
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-policy-controller
+  namespace: cosign-system
+data:
+  enable-oci11: "true"
+

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -18,13 +18,21 @@ package webhook
 import (
 	"context"
 	"crypto"
+	"encoding/json"
 	"encoding/pem"
+	"fmt"
+	"io"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"knative.dev/pkg/logging"
 
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci"
+	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+	"github.com/sigstore/cosign/v2/pkg/oci/static"
+	policycontrollerconfig "github.com/sigstore/policy-controller/pkg/config"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
@@ -57,6 +65,10 @@ func valid(ctx context.Context, ref name.Reference, keys []crypto.PublicKey, has
 // For testing
 var cosignVerifySignatures = cosign.VerifyImageSignatures
 var cosignVerifyAttestations = cosign.VerifyImageAttestations
+var ociremoteResolveDigest = ociremote.ResolveDigest
+var ociremoteReferrers = ociremote.Referrers
+var ociremoteSignedImage = ociremote.SignedImage
+var testProcessAttestationArtifact = processAttestationArtifact
 
 func validSignatures(ctx context.Context, ref name.Reference, checkOpts *cosign.CheckOpts) ([]oci.Signature, error) {
 	checkOpts.ClaimVerifier = cosign.SimpleClaimVerifier
@@ -65,9 +77,97 @@ func validSignatures(ctx context.Context, ref name.Reference, checkOpts *cosign.
 }
 
 func validAttestations(ctx context.Context, ref name.Reference, checkOpts *cosign.CheckOpts) ([]oci.Signature, error) {
+	cfg := policycontrollerconfig.FromContextOrDefaults(ctx)
+	if cfg.EnableOCI11 {
+		if attestations, err := discoverAttestationsOCI11(ctx, ref, checkOpts); err == nil {
+			return attestations, nil
+		}
+	}
+
 	checkOpts.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
 	attestations, _, err := cosignVerifyAttestations(ctx, ref, checkOpts)
 	return attestations, err
+}
+
+func discoverAttestationsOCI11(ctx context.Context, ref name.Reference, checkOpts *cosign.CheckOpts) ([]oci.Signature, error) {
+	digest, err := ociremoteResolveDigest(ref, checkOpts.RegistryClientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	indexManifest, err := ociremoteReferrers(digest, "", checkOpts.RegistryClientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	var allSigs []oci.Signature
+	for _, manifest := range indexManifest.Manifests {
+		if strings.Contains(manifest.ArtifactType, "in-toto") {
+			sigs, err := testProcessAttestationArtifact(manifest, digest.Repository, checkOpts.RegistryClientOpts)
+			if err != nil {
+				logging.FromContext(ctx).Debugf("Failed to process attestation artifact: %v", err)
+				continue
+			}
+			allSigs = append(allSigs, sigs...)
+		}
+	}
+
+	if len(allSigs) == 0 {
+		return nil, fmt.Errorf("no attestations found")
+	}
+	return allSigs, nil
+}
+
+func processAttestationArtifact(result v1.Descriptor, repository name.Repository, registryOpts []ociremote.Option) ([]oci.Signature, error) {
+	attRef, err := name.ParseReference(fmt.Sprintf("%s@%s", repository, result.Digest.String()))
+	if err != nil {
+		return nil, err
+	}
+
+	signedEntity, err := ociremoteSignedImage(attRef, registryOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	layers, err := signedEntity.Layers()
+	if err != nil || len(layers) == 0 {
+		return nil, fmt.Errorf("no layers found")
+	}
+
+	rc, err := layers[0].Uncompressed()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	dsseEnvelope, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	var envelope struct {
+		Payload    string `json:"payload"`
+		Signatures []struct {
+			Sig string `json:"sig"`
+		} `json:"signatures"`
+	}
+
+	if err := json.Unmarshal(dsseEnvelope, &envelope); err != nil {
+		return nil, err
+	}
+
+	var signatures []oci.Signature
+	for _, sig := range envelope.Signatures {
+		payloadStruct := map[string]interface{}{
+			"payload": envelope.Payload,
+		}
+		payloadBytes, _ := json.Marshal(payloadStruct)
+		if ociSig, err := static.NewSignature(payloadBytes, sig.Sig); err == nil {
+			signatures = append(signatures, ociSig)
+		}
+	}
+
+	return signatures, nil
 }
 
 func parsePems(b []byte) []*pem.Block {

--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -1348,9 +1348,13 @@ func normalizeArchitecture(cf *v1.ConfigFile) string {
 // checkOptsFromAuthority creates the necessary options for calling Cosign
 // verify functions (signatures and attestations).
 func checkOptsFromAuthority(ctx context.Context, authority webhookcip.Authority, remoteOpts ...ociremote.Option) (*cosign.CheckOpts, error) {
+	// Get the policy controller configuration to check if OCI 1.1 is enabled
+	cfg := policycontrollerconfig.FromContextOrDefaults(ctx)
+
 	ret := &cosign.CheckOpts{
 		RegistryClientOpts: remoteOpts,
 		NewBundleFormat:    authority.SignatureFormat == "bundle",
+		ExperimentalOCI11:  cfg.EnableOCI11,
 	}
 
 	// Add in the identities for verification purposes

--- a/test/e2e_test_cluster_image_policy_with_oci11_attestations.sh
+++ b/test/e2e_test_cluster_image_policy_with_oci11_attestations.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test validates that the policy controller can discover and verify
+# attestations stored using the OCI 1.1 referrers API (as opposed to the
+# legacy tag-based discovery). Google Cloud Build stores attestations this way.
+
+set -ex
+
+# Use a public image with OCI 1.1 attestations from Google Cloud Build
+# This image has attestations discoverable via the OCI 1.1 referrers API
+export TEST_IMAGE="us-docker.pkg.dev/cloudrun/container/hello@sha256:ee5d02305108fd8d65a8299a26cf01b6f976986fd04062e31280f97f21a91e3d"
+
+# Namespace for testing
+export NS="demo-oci11-attest"
+
+echo '::group:: Create test namespace'
+kubectl create namespace ${NS}
+echo '::endgroup::'
+
+echo '::group:: Enable OCI 1.1 support in policy controller'
+kubectl patch configmap/config-policy-controller \
+  --namespace cosign-system \
+  --type merge \
+  --patch '{"data":{"enable-oci11":"true"}}'
+# Allow for propagation
+sleep 5
+echo '::endgroup::'
+
+echo '::group:: Create ClusterImagePolicy for OCI 1.1 attestations'
+# This policy uses a static key (Google Cloud Build public key) to verify
+# attestations discoverable via OCI 1.1 referrers API
+kubectl apply -f - <<EOF
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: oci11-attestation-policy
+spec:
+  images:
+  - glob: "us-docker.pkg.dev/cloudrun/container/**"
+  authorities:
+  - name: google-cloud-build-key
+    key:
+      data: |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg9KII7kzr/30HBluf00y9WwtMFkE
+        qc3oCcFVH3QJ37IBLUv/MUApbnNHFfD75ayJ/a0F45xa+MLv5zoep+GxsA==
+        -----END PUBLIC KEY-----
+    attestations:
+    - name: require-provenance
+      predicateType: https://slsa.dev/provenance/v1
+      policy:
+        type: cue
+        data: |
+          predicateType: "https://slsa.dev/provenance/v1"
+EOF
+echo '::endgroup::'
+
+# Allow time for the policy to be picked up
+sleep 5
+
+echo '::group:: Test: Create pod with OCI 1.1 attestations (should succeed)'
+kubectl run -n ${NS} oci11-test \
+  --image=${TEST_IMAGE} \
+  --restart=Never \
+  --command -- /hello
+
+# Wait for pod to be admitted
+sleep 3
+
+# Check if pod was created successfully
+if ! kubectl get pod -n ${NS} oci11-test; then
+  echo "FAIL: Pod with OCI 1.1 attestations was not created"
+  kubectl describe pod -n ${NS} oci11-test || true
+  exit 1
+else
+  echo "SUCCESS: Pod with OCI 1.1 attestations was created successfully"
+fi
+echo '::endgroup::'
+
+echo '::group:: Cleanup'
+kubectl delete pod -n ${NS} oci11-test --ignore-not-found=true
+kubectl delete clusterimagepolicy oci11-attestation-policy --ignore-not-found=true
+kubectl delete namespace ${NS} --ignore-not-found=true
+
+# Reset config to default
+kubectl patch configmap/config-policy-controller \
+  --namespace cosign-system \
+  --type merge \
+  --patch '{"data":{"enable-oci11":"false"}}'
+echo '::endgroup::'
+
+echo "OCI 1.1 attestation test PASSED"
+


### PR DESCRIPTION
Closes #1895 

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Some provenance attestation implementation, for instance Google Cloud Build, store attestations using the [OCI 1.1](https://opencontainers.org/posts/blog/2024-03-13-image-and-distribution-1-1/) referrers API rather than the traditional `<subject digest>.att` naming scheme. As is, the policy controller is thus unable to verify valid in-toto provenance attestations generated by Google Cloud Build. This is demonstrated in #1895.

This PR Implements OCI 1.1 referrers API for discovering attestations with automatic fallback to legacy tag-based discovery. This enables policy-controller to work with modern OCI 1.1 registries while maintaining backward compatibility, regardless if the new sigstore bundle format is used or not.

Technical implementation:
- Uses ociremote.Referrers() to discover attestation artifacts
- Filters by artifact types: in-toto, slsa, provenance, attestation, dsse
- Processes DSSE envelopes and creates compatible oci.Signature objects
- Maintains proper payload format for AttestationToPayloadJSON compatibility

### BEFORE

<img width="1418" height="1094" alt="Image" src="https://github.com/user-attachments/assets/e3aea6eb-e1b9-4409-a3c1-af514db345f7" />

### AFTER

<img width="1374" height="1466" alt="Screenshot 2025-10-13 at 16 52 14" src="https://github.com/user-attachments/assets/fd3cdd7e-4a27-46e4-9b4f-4c57360f7525" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Add 'enable-oci11' configuration option
- Implement custom OCI 1.1 referrers API discovery in validAttestations()
- Add CLI flag '--enable-oci11' to policy-tester for testing
- Automatic fallback to legacy cosign discovery when OCI 1.1 fails

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
