### PR TITLE
Add --resource-names flag to customize monitored resources

### DIFF
--- a/.github/workflows/kind-cluster-resource-names.yaml
+++ b/.github/workflows/kind-cluster-resource-names.yaml
@@ -1,0 +1,93 @@
+# Copyright 2024 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test policy-controller with --resource-names flag
+
+on:
+  pull_request:
+    branches: [ 'main', 'release-*' ]
+
+defaults:
+  run:
+    shell: bash
+
+permissions: read-all
+
+jobs:
+  resource-names-flag-test:
+    name: Test --resource-names flag functionality
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        k8s-version:
+          - v1.31.x
+          - v1.32.x
+          - v1.33.x
+          - v1.34.x
+
+    env:
+      KO_DOCKER_REPO: "registry.local:5000/policy-controller"
+      SCAFFOLDING_RELEASE_VERSION: "v0.7.27"
+      GO111MODULE: on
+      GOFLAGS: -ldflags=-s -ldflags=-w
+      KOCACHE: ~/ko
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version-file: './go.mod'
+          check-latest: true
+
+      # will use the latest release available for ko
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+
+      - uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2.1.0
+
+      - name: Install yq
+        uses: mikefarah/yq@065b200af9851db0d5132f50bc10b1406ea5c0a8 # v4.50.1
+
+      - name: Setup mirror
+        uses: chainguard-dev/actions/setup-mirror@main
+        with:
+          mirror: mirror.gcr.io
+
+      - uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+
+      - name: Install cluster + sigstore
+        uses: sigstore/scaffolding/actions/setup@main
+        with:
+          k8s-version: ${{ matrix.k8s-version }}
+          version: ${{ env.SCAFFOLDING_RELEASE_VERSION }}
+
+      - name: Install policy-controller
+        env:
+          GIT_HASH: ${{ github.sha }}
+          GIT_VERSION: ci
+          LDFLAGS: ""
+          POLICY_CONTROLLER_YAML: test/kustomize-resource-names/policy-controller-e2e.yaml
+          KO_PREFIX: registry.local:5000/policy-controller
+          POLICY_CONTROLLER_ARCHS: linux/amd64
+        run: |
+          make ko-policy-controller
+
+      - name: Run --resource-names flag tests
+        run: |
+          ./test/e2e_test_resource_names_flag.sh
+
+      - name: Collect diagnostics
+        if: ${{ failure() }}
+        uses: chainguard-dev/actions/kind-diag@6b6aeacf5f8f4854707392e7708773a7f510b611 # main

--- a/test/e2e_test_resource_names_flag.sh
+++ b/test/e2e_test_resource_names_flag.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2E test for the --resource-names flag functionality.
+#
+# This test validates selective resource monitoring by configuring the policy
+# controller to monitor only ReplicaSets and DaemonSets, then verifying:
+# 1. Unmonitored resources (Pods, Deployments) are allowed without policy checks
+# 2. Monitored resources (ReplicaSets, DaemonSets) are properly validated
+# 3. Signed images are allowed for monitored resources
+
+set -ex
+
+if [[ -z "${KO_DOCKER_REPO}" ]]; then
+  echo "Must specify env variable KO_DOCKER_REPO"
+  exit 1
+fi
+
+# Variables
+export NS=demo-resource-names
+export demoimage="ghcr.io/sigstore/timestamp-server@sha256:dcf2f3a640bfb0a5d17aabafb34b407fe4403363c715718ab305a62b3606540d"
+
+echo "=========================================="
+echo "Testing custom resource monitoring"
+echo "=========================================="
+
+# Step 1: Deploy policy controller with ONLY ReplicaSets and DaemonSets monitored
+echo '::group:: Deploy policy-controller with custom resources (replicasets,daemonsets only)'
+kubectl apply -f <(kustomize build ./test/kustomize-resource-names)
+kubectl rollout status --timeout 5m --namespace cosign-system deployments/webhook
+echo '::endgroup::'
+
+# Step 2: Verify webhook configuration
+echo '::group:: Verify webhook is configured for custom resources'
+# Wait for webhook configuration to be updated with custom resources
+echo "Waiting for webhook configuration to be updated..."
+for i in {1..30}; do
+  if kubectl get validatingwebhookconfiguration policy.sigstore.dev -o yaml | grep -q "replicasets"; then
+    echo "replicasets found in webhook configuration"
+    break
+  fi
+  echo "Attempt $i/30: Waiting for webhook configuration update..."
+  sleep 2
+done
+
+# Check that webhook rules include replicasets and daemonsets
+kubectl get validatingwebhookconfiguration policy.sigstore.dev -o yaml | grep -q "replicasets" || {
+  echo "ERROR: replicasets not found in webhook configuration"
+  kubectl get validatingwebhookconfiguration policy.sigstore.dev -o yaml
+  exit 1
+}
+kubectl get validatingwebhookconfiguration policy.sigstore.dev -o yaml | grep -q "daemonsets" || {
+  echo "ERROR: daemonsets not found in webhook configuration"
+  kubectl get validatingwebhookconfiguration policy.sigstore.dev -o yaml
+  exit 1
+}
+echo "Webhook correctly configured for ReplicaSet and DaemonSet"
+echo '::endgroup::'
+
+# Step 3: Create test namespace
+echo '::group:: Create and label test namespace'
+kubectl create namespace ${NS}
+kubectl label namespace ${NS} policy.sigstore.dev/include=true
+echo '::endgroup::'
+
+# Step 4: Deploy ClusterImagePolicy
+echo '::group:: Deploy ClusterImagePolicy requiring signatures'
+cat <<EOF | kubectl apply -f -
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-resource-names
+spec:
+  images:
+  - glob: "**"
+  authorities:
+  - keyless:
+      url: https://fulcio.sigstore.dev
+      identities:
+      - issuerRegExp: https://token.actions.githubusercontent.com
+        subjectRegExp: https://github.com/sigstore/timestamp-.*/.github/workflows/.*
+EOF
+sleep 5
+echo '::endgroup::'
+
+# Step 5: Test that Pods are NOT monitored
+# Unmonitored resources should be allowed without policy checks
+echo '::group:: Test that Pods are NOT monitored'
+if ! cat <<EOF | kubectl apply -f -; then
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-unmonitored
+  namespace: ${NS}
+spec:
+  containers:
+  - name: test
+    image: busybox:latest
+    command: ["sleep", "3600"]
+EOF
+  echo "ERROR: Pod should be allowed since Pods are not in monitored resources"
+  exit 1
+fi
+echo "SUCCESS: Pod was allowed (not monitored)"
+kubectl delete pod test-pod-unmonitored -n ${NS} --ignore-not-found=true
+echo '::endgroup::'
+
+# Step 6: Test that Deployments are NOT monitored
+echo '::group:: Test that Deployments are NOT monitored'
+if ! cat <<EOF | kubectl apply -f -; then
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment-unmonitored
+  namespace: ${NS}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-unmonitored
+  template:
+    metadata:
+      labels:
+        app: test-unmonitored
+    spec:
+      containers:
+      - name: test
+        image: busybox:latest
+        command: ["sleep", "3600"]
+EOF
+  echo "ERROR: Deployment should be allowed since Deployments are not in monitored resources"
+  exit 1
+fi
+echo "SUCCESS: Deployment was allowed (not monitored)"
+kubectl delete deployment test-deployment-unmonitored -n ${NS} --ignore-not-found=true
+echo '::endgroup::'
+
+# Step 7: Test that ReplicaSets ARE monitored
+# Monitored resources should be validated and blocked if policy is violated
+echo '::group:: Test that ReplicaSets ARE monitored'
+if cat <<EOF | kubectl apply -f -; then
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: test-replicaset-monitored
+  namespace: ${NS}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-monitored
+  template:
+    metadata:
+      labels:
+        app: test-monitored
+    spec:
+      containers:
+      - name: test
+        image: busybox:latest
+        command: ["sleep", "3600"]
+EOF
+  echo "ERROR: ReplicaSet should be blocked since ReplicaSets are monitored and image is not signed"
+  kubectl delete replicaset test-replicaset-monitored -n ${NS} --ignore-not-found=true
+  exit 1
+fi
+echo "SUCCESS: ReplicaSet was blocked (monitored)"
+echo '::endgroup::'
+
+# Step 8: Test that DaemonSets ARE monitored
+echo '::group:: Test that DaemonSets ARE monitored'
+if cat <<EOF | kubectl apply -f -; then
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-daemonset-monitored
+  namespace: ${NS}
+spec:
+  selector:
+    matchLabels:
+      app: test-monitored-ds
+  template:
+    metadata:
+      labels:
+        app: test-monitored-ds
+    spec:
+      containers:
+      - name: test
+        image: busybox:latest
+        command: ["sleep", "3600"]
+EOF
+  echo "ERROR: DaemonSet should be blocked since DaemonSets are monitored and image is not signed"
+  kubectl delete daemonset test-daemonset-monitored -n ${NS} --ignore-not-found=true
+  exit 1
+fi
+echo "SUCCESS: DaemonSet was blocked (monitored)"
+echo '::endgroup::'
+
+# Step 9: Test with properly signed image
+# Verify that policy validation logic works correctly for compliant images
+echo '::group:: Test that signed images are allowed for monitored resources'
+if ! cat <<EOF | kubectl apply -f -; then
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: test-replicaset-signed
+  namespace: ${NS}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-signed
+  template:
+    metadata:
+      labels:
+        app: test-signed
+    spec:
+      containers:
+      - name: test
+        image: ${demoimage}
+EOF
+  echo "ERROR: ReplicaSet with signed image should be allowed"
+  exit 1
+fi
+echo "SUCCESS: ReplicaSet with signed image was allowed"
+kubectl delete replicaset test-replicaset-signed -n ${NS} --ignore-not-found=true
+echo '::endgroup::'
+
+echo "=========================================="
+echo "All custom resource tests passed!"
+echo "=========================================="
+
+# Cleanup
+kubectl delete namespace ${NS} --ignore-not-found=true
+kubectl delete clusterimagepolicy image-policy-resource-names --ignore-not-found=true

--- a/test/kustomize-resource-names/kustomization.yaml
+++ b/test/kustomize-resource-names/kustomization.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - policy-controller-e2e.yaml
+
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --resource-names=replicasets,daemonsets
+    target:
+      kind: Deployment
+      name: webhook


### PR DESCRIPTION
## Summary

This PR adds the `--resource-names` flag to allow operators to selectively monitor specific Kubernetes resource types. This addresses issue #1388.

## Background

This PR is an updated version of #1687, which has become outdated and requires rebasing. This PR provides the same functionality with an updated implementation.

## Changes

### Core Implementation
- **New flag**: `--resource-names` with default value covering all resource types (pods, replicasets, deployments, statefulsets, daemonsets, jobs, cronjobs)
- **Dynamic types map**: Constructs the resource types map based on specified resources at startup
- **Validation**: Validates resource names and logs warnings for invalid entries
- **Fail-fast**: Terminates if no valid resources are specified
- **Warning message**: Displays warning when using custom resource names to alert users about potential UX issues

### Testing
- **E2E test**: `test/e2e_test_resource_names_flag.sh` validates selective monitoring
- **Kustomize example**: `test/kustomize-resource-names/` demonstrates configuration
- **CI workflow**: `.github/workflows/kind-cluster-resource-names.yaml` for automated testing

## Behavior

### Default (unchanged)
```bash
./webhook
# Monitors: pods, replicasets, deployments, statefulsets, daemonsets, jobs, cronjobs
```

### Custom resources
```bash
./webhook --resource-names=replicasets,daemonsets
# Monitors only: replicasets, daemonsets
# WARNING: Displays warning about potential UX issues
```

## Warning Rationale

When parent resources (e.g., Deployments, ReplicaSets) are not monitored, users will not receive policy violation feedback when creating them, even though the Pods they create may violate policies. This can lead to poor user experience.

## Testing

Run the E2E test:
```bash
./test/e2e_test_resource_names_flag.sh
```

Deploy with specific resources:
```bash
kubectl apply -k test/kustomize-resource-names/
```

## Backward Compatibility

✅ Default behavior unchanged - all resources monitored by default
✅ Existing deployments continue to work without modification
✅ No breaking changes

## CI Note

The CI failure in `ClusterImagePolicy e2e tests with TrustRoot - Bring Your Own Keys (v1.32.x, repository)` appears to be unrelated to this PR:

- The same test has also failed on the `main` branch ([#17047096031](https://github.com/sigstore/policy-controller/actions/runs/17047096031))
- 11 out of 12 matrix jobs passed in this PR
- This PR does not modify TrustRoot reconciliation logic

## Related Issues and PRs

- Resolves #1388
- Closes #1687 (supersedes with updated implementation)