### PR TITLE
fix(webhook): verify OCI 1.1 attestation signatures before trusting them

### DIFF
--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/oci"
+	"github.com/sigstore/cosign/v3/pkg/oci/empty"
+	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	policycontrollerconfig "github.com/sigstore/policy-controller/pkg/config"
@@ -65,6 +67,7 @@ func valid(ctx context.Context, ref name.Reference, keys []crypto.PublicKey, has
 // For testing
 var cosignVerifySignatures = cosign.VerifyImageSignatures
 var cosignVerifyAttestations = cosign.VerifyImageAttestations
+var cosignVerifyAttestation = cosign.VerifyImageAttestation
 var ociremoteResolveDigest = ociremote.ResolveDigest
 var ociremoteReferrers = ociremote.Referrers
 var ociremoteSignedImage = ociremote.SignedImage
@@ -115,7 +118,24 @@ func discoverAttestationsOCI11(ctx context.Context, ref name.Reference, checkOpt
 	if len(allSigs) == 0 {
 		return nil, fmt.Errorf("no attestations found")
 	}
-	return allSigs, nil
+
+	hash, err := v1.NewHash(digest.Identifier())
+	if err != nil {
+		return nil, fmt.Errorf("resolving image digest: %w", err)
+	}
+	atts := empty.Signatures()
+	for _, s := range allSigs {
+		atts, err = mutate.AppendSignatures(atts, false, s)
+		if err != nil {
+			return nil, fmt.Errorf("collecting OCI 1.1 attestations: %w", err)
+		}
+	}
+	checkOpts.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
+	verified, _, err := cosignVerifyAttestation(ctx, atts, hash, checkOpts)
+	if err != nil {
+		return nil, err
+	}
+	return verified, nil
 }
 
 func processAttestationArtifact(result v1.Descriptor, repository name.Repository, registryOpts []ociremote.Option) ([]oci.Signature, error) {
@@ -145,29 +165,28 @@ func processAttestationArtifact(result v1.Descriptor, repository name.Repository
 		return nil, err
 	}
 
-	var envelope struct {
-		Payload    string `json:"payload"`
-		Signatures []struct {
+	var probe struct {
+		PayloadType string `json:"payloadType"`
+		Payload     string `json:"payload"`
+		Signatures  []struct {
 			Sig string `json:"sig"`
 		} `json:"signatures"`
 	}
+	if err := json.Unmarshal(dsseEnvelope, &probe); err != nil {
+		return nil, fmt.Errorf("invalid DSSE envelope: %w", err)
+	}
+	if probe.PayloadType == "" || probe.Payload == "" || len(probe.Signatures) == 0 {
+		return nil, fmt.Errorf("malformed DSSE envelope: missing payloadType, payload, or signatures")
+	}
 
-	if err := json.Unmarshal(dsseEnvelope, &envelope); err != nil {
+	// One oci.Signature per attestation referrer. The full DSSE envelope is the
+	// signature payload; cosign.verifyOCIAttestation re-parses payloadType and
+	// signatures from this payload before performing cryptographic verification.
+	att, err := static.NewAttestation(dsseEnvelope)
+	if err != nil {
 		return nil, err
 	}
-
-	var signatures []oci.Signature
-	for _, sig := range envelope.Signatures {
-		payloadStruct := map[string]interface{}{
-			"payload": envelope.Payload,
-		}
-		payloadBytes, _ := json.Marshal(payloadStruct)
-		if ociSig, err := static.NewSignature(payloadBytes, sig.Sig); err == nil {
-			signatures = append(signatures, ociSig)
-		}
-	}
-
-	return signatures, nil
+	return []oci.Signature{att}, nil
 }
 
 func parsePems(b []byte) []*pem.Block {

--- a/pkg/webhook/validation_oci11_security_test.go
+++ b/pkg/webhook/validation_oci11_security_test.go
@@ -1,0 +1,119 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/oci"
+	cosignremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	policycontrollerconfig "github.com/sigstore/policy-controller/pkg/config"
+)
+
+// TestValidAttestationsOCI11_RejectsForgedDSSE asserts that an attacker who
+// controls only the OCI registry cannot get an unsigned/forged DSSE envelope
+// accepted as a "verified" attestation by validAttestations when EnableOCI11
+// is set. Prior to the fix, discoverAttestationsOCI11/processAttestationArtifact
+// returned the envelope as a verified oci.Signature without ever invoking a
+// cryptographic verifier; ValidatePolicyAttestationsForAuthority then treated
+// len(result) > 0 as success and admitted the image. This regression test
+// pins the post-fix behavior: with no verifier, no trust roots, and a forged
+// signature byte, validAttestations must return an error rather than a
+// signature.
+func TestValidAttestationsOCI11_RejectsForgedDSSE(t *testing.T) {
+	ctx := context.Background()
+
+	origResolve := ociremoteResolveDigest
+	origReferrers := ociremoteReferrers
+	origSignedImg := ociremoteSignedImage
+	defer func() {
+		ociremoteResolveDigest = origResolve
+		ociremoteReferrers = origReferrers
+		ociremoteSignedImage = origSignedImg
+	}()
+
+	cfg := &policycontrollerconfig.PolicyControllerConfig{EnableOCI11: true}
+	ctx = policycontrollerconfig.ToContext(ctx, cfg)
+
+	imageRef := name.MustParseReference(
+		"attacker.example.com/evil/img@sha256:" +
+			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	ociremoteResolveDigest = func(_ name.Reference, _ ...cosignremote.Option) (name.Digest, error) {
+		return imageRef.(name.Digest), nil
+	}
+	ociremoteReferrers = func(_ name.Digest, _ string, _ ...cosignremote.Option) (*v1.IndexManifest, error) {
+		return &v1.IndexManifest{
+			Manifests: []v1.Descriptor{
+				{
+					ArtifactType: "application/vnd.dsse.envelope.v1+json; in-toto",
+					Digest: v1.Hash{
+						Algorithm: "sha256",
+						Hex:       "0123456789012345678901234567890123456789012345678901234567890123",
+					},
+				},
+			},
+		}, nil
+	}
+
+	innerStatement := map[string]interface{}{
+		"_type":         "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"subject": []map[string]interface{}{
+			{"name": "attacker.example.com/evil/img", "digest": map[string]string{"sha256": "aaaa"}},
+		},
+		"predicate": map[string]interface{}{
+			"builder":   map[string]string{"id": "https://attacker.example.com"},
+			"buildType": "https://attacker.example.com/forged",
+		},
+	}
+	stmtJSON, _ := json.Marshal(innerStatement)
+	dsse, _ := json.Marshal(map[string]interface{}{
+		"payload":     base64.StdEncoding.EncodeToString(stmtJSON),
+		"payloadType": "application/vnd.in-toto+json",
+		"signatures": []map[string]string{
+			{"sig": "ATTACKER_FORGED_SIGNATURE"},
+		},
+	})
+
+	ociremoteSignedImage = func(_ name.Reference, _ ...cosignremote.Option) (oci.SignedImage, error) {
+		return &mockSignedImage{layers: []v1.Layer{&mockLayer{content: dsse}}}, nil
+	}
+
+	// A CheckOpts with no SigVerifier, no RootCerts, no TrustedMaterial -
+	// the attacker holds no signing key, and the verifier has no trust roots,
+	// so verification MUST fail. Prior to the fix this returned 1 "verified"
+	// attestation.
+	checkOpts := &cosign.CheckOpts{
+		Identities: []cosign.Identity{
+			{Issuer: "https://accounts.google.com", Subject: "builder@google"},
+		},
+	}
+
+	sigs, err := validAttestations(ctx, imageRef, checkOpts)
+	if err == nil {
+		t.Fatalf("OCI 1.1 attestation bypass regression: validAttestations returned %d 'verified' attestations for a forged DSSE envelope with no verifier configured", len(sigs))
+	}
+	if len(sigs) != 0 {
+		t.Fatalf("expected zero verified attestations on error, got %d", len(sigs))
+	}
+}

--- a/pkg/webhook/validation_oci11_security_test.go
+++ b/pkg/webhook/validation_oci11_security_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -45,11 +46,23 @@ func TestValidAttestationsOCI11_RejectsForgedDSSE(t *testing.T) {
 	origResolve := ociremoteResolveDigest
 	origReferrers := ociremoteReferrers
 	origSignedImg := ociremoteSignedImage
+	origVerifyAtts := cosignVerifyAttestations
 	defer func() {
 		ociremoteResolveDigest = origResolve
 		ociremoteReferrers = origReferrers
 		ociremoteSignedImage = origSignedImg
+		cosignVerifyAttestations = origVerifyAtts
 	}()
+
+	// validAttestations falls through to cosign.VerifyImageAttestations when
+	// the OCI 1.1 path returns an error. Stub the legacy path so this test
+	// stays deterministic (no real registry / network calls) and so the only
+	// way validAttestations can return a non-empty result is the OCI 1.1
+	// branch — which is exactly what we want to assert does not accept the
+	// forged envelope.
+	cosignVerifyAttestations = func(_ context.Context, _ name.Reference, _ *cosign.CheckOpts, _ ...name.Option) ([]oci.Signature, bool, error) {
+		return nil, false, errors.New("legacy attestation fetch stubbed for test")
+	}
 
 	cfg := &policycontrollerconfig.PolicyControllerConfig{EnableOCI11: true}
 	ctx = policycontrollerconfig.ToContext(ctx, cfg)

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -3928,8 +3928,7 @@ func TestProcessAttestationArtifact(t *testing.T) {
 			name:       "valid DSSE envelope",
 			descriptor: descriptor,
 			mockImage: func(ref name.Reference, opts ...remote.Option) (oci.SignedImage, error) {
-				// Valid DSSE envelope with proper base64 payload
-				dsseContent := []byte(`{"payload":"eyJ0ZXN0IjoidmFsdWUifQ==","signatures":[{"sig":"c2lnbmF0dXJl"}]}`)
+				dsseContent := []byte(`{"payloadType":"application/vnd.in-toto+json","payload":"eyJ0ZXN0IjoidmFsdWUifQ==","signatures":[{"sig":"c2lnbmF0dXJl"}]}`)
 				return &mockSignedImage{
 					layers: []v1.Layer{
 						&mockLayer{content: dsseContent},
@@ -3943,15 +3942,17 @@ func TestProcessAttestationArtifact(t *testing.T) {
 			name:       "multiple signatures in envelope",
 			descriptor: descriptor,
 			mockImage: func(ref name.Reference, opts ...remote.Option) (oci.SignedImage, error) {
-				dsseContent := []byte(`{"payload":"eyJ0ZXN0IjoidmFsdWUifQ==","signatures":[{"sig":"c2lnMQ=="},{"sig":"c2lnMg=="}]}`)
+				dsseContent := []byte(`{"payloadType":"application/vnd.in-toto+json","payload":"eyJ0ZXN0IjoidmFsdWUifQ==","signatures":[{"sig":"c2lnMQ=="},{"sig":"c2lnMg=="}]}`)
 				return &mockSignedImage{
 					layers: []v1.Layer{
 						&mockLayer{content: dsseContent},
 					},
 				}, nil
 			},
+			// One oci.Signature per envelope; DSSE verification handles the
+			// per-signer threshold internally.
 			wantErr:      false,
-			wantSigCount: 2,
+			wantSigCount: 1,
 		},
 		{
 			name: "invalid digest format",
@@ -3997,18 +3998,36 @@ func TestProcessAttestationArtifact(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			// A DSSE envelope with zero signatures is structurally invalid;
+			// processAttestationArtifact must reject it rather than silently
+			// returning zero "verified" attestations.
 			name:       "empty signatures array",
 			descriptor: descriptor,
 			mockImage: func(ref name.Reference, opts ...remote.Option) (oci.SignedImage, error) {
-				dsseContent := []byte(`{"payload":"eyJ0ZXN0IjoidmFsdWUifQ==","signatures":[]}`)
+				dsseContent := []byte(`{"payloadType":"application/vnd.in-toto+json","payload":"eyJ0ZXN0IjoidmFsdWUifQ==","signatures":[]}`)
 				return &mockSignedImage{
 					layers: []v1.Layer{
 						&mockLayer{content: dsseContent},
 					},
 				}, nil
 			},
-			wantErr:      false,
-			wantSigCount: 0,
+			wantErr: true,
+		},
+		{
+			// DSSE envelopes must declare a payloadType; missing payloadType is
+			// not a real DSSE envelope and would never pass verification, so
+			// reject it explicitly rather than treating it as a valid signature.
+			name:       "DSSE envelope missing payloadType",
+			descriptor: descriptor,
+			mockImage: func(ref name.Reference, opts ...remote.Option) (oci.SignedImage, error) {
+				dsseContent := []byte(`{"payload":"eyJ0ZXN0IjoidmFsdWUifQ==","signatures":[{"sig":"c2ln"}]}`)
+				return &mockSignedImage{
+					layers: []v1.Layer{
+						&mockLayer{content: dsseContent},
+					},
+				}, nil
+			},
+			wantErr: true,
 		},
 	}
 
@@ -4028,6 +4047,17 @@ func TestProcessAttestationArtifact(t *testing.T) {
 	}
 }
 
+// passthroughVerifyAttestation returns the input attestations as if they
+// verified, for tests that exercise discovery logic without performing
+// real cryptographic verification.
+func passthroughVerifyAttestation(_ context.Context, atts oci.Signatures, _ v1.Hash, _ *cosign.CheckOpts) ([]oci.Signature, bool, error) {
+	sigs, err := atts.Get()
+	if err != nil {
+		return nil, false, err
+	}
+	return sigs, true, nil
+}
+
 func TestDiscoverAttestationsOCI11SuccessfulDiscovery(t *testing.T) {
 	ctx := context.Background()
 	ref := name.MustParseReference("example.com/test@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234")
@@ -4037,11 +4067,14 @@ func TestDiscoverAttestationsOCI11SuccessfulDiscovery(t *testing.T) {
 	origResolve := ociremoteResolveDigest
 	origReferrers := ociremoteReferrers
 	origProcessAtt := testProcessAttestationArtifact
+	origVerifyAtt := cosignVerifyAttestation
 	defer func() {
 		ociremoteResolveDigest = origResolve
 		ociremoteReferrers = origReferrers
 		testProcessAttestationArtifact = origProcessAtt
+		cosignVerifyAttestation = origVerifyAtt
 	}()
+	cosignVerifyAttestation = passthroughVerifyAttestation
 
 	ociremoteResolveDigest = func(ref name.Reference, opts ...remote.Option) (name.Digest, error) {
 		return name.MustParseReference("example.com/test@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234").(name.Digest), nil
@@ -4097,11 +4130,14 @@ func TestDiscoverAttestationsOCI11MixedArtifacts(t *testing.T) {
 	origResolve := ociremoteResolveDigest
 	origReferrers := ociremoteReferrers
 	origProcessAtt := testProcessAttestationArtifact
+	origVerifyAtt := cosignVerifyAttestation
 	defer func() {
 		ociremoteResolveDigest = origResolve
 		ociremoteReferrers = origReferrers
 		testProcessAttestationArtifact = origProcessAtt
+		cosignVerifyAttestation = origVerifyAtt
 	}()
+	cosignVerifyAttestation = passthroughVerifyAttestation
 
 	ociremoteResolveDigest = func(ref name.Reference, opts ...remote.Option) (name.Digest, error) {
 		return name.MustParseReference("example.com/test@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234").(name.Digest), nil
@@ -4168,11 +4204,14 @@ func TestDiscoverAttestationsOCI11PartialProcessingFailure(t *testing.T) {
 	origResolve := ociremoteResolveDigest
 	origReferrers := ociremoteReferrers
 	origProcessAtt := testProcessAttestationArtifact
+	origVerifyAtt := cosignVerifyAttestation
 	defer func() {
 		ociremoteResolveDigest = origResolve
 		ociremoteReferrers = origReferrers
 		testProcessAttestationArtifact = origProcessAtt
+		cosignVerifyAttestation = origVerifyAtt
 	}()
+	cosignVerifyAttestation = passthroughVerifyAttestation
 
 	ociremoteResolveDigest = func(ref name.Reference, opts ...remote.Option) (name.Digest, error) {
 		return name.MustParseReference("example.com/test@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234").(name.Digest), nil


### PR DESCRIPTION
## Summary

When `enable-oci11=true`, `discoverAttestationsOCI11` fetched referrer attestations and returned them via `processAttestationArtifact` without ever invoking a cryptographic verifier. The caller `ValidatePolicyAttestationsForAuthority` treats `len(verifiedAttestations) > 0` as a successful authority check, so any image carrying an OCI 1.1 referrer whose `ArtifactType` contains `"in-toto"` was admitted regardless of whether the embedded DSSE envelope carried any valid signature, certificate, or transparency-log entry.

The path was introduced in #1894 and is present in `v0.15.x` / `main`.

This PR:

- Routes the discovered attestations through `cosign.VerifyImageAttestation`, which runs the same signature / cert / identity / transparency-log / claim checks as the legacy attestation path.
- Fixes `processAttestationArtifact` to hand the full DSSE envelope to `static.NewAttestation` (instead of an ad-hoc JSON wrapper that `cosign.verifyOCIAttestation` could not parse), and to reject envelopes that are missing `payloadType` / `payload` / `signatures`.
- Adds `TestValidAttestationsOCI11_RejectsForgedDSSE`, a regression test that drives `validAttestations` end-to-end with a forged DSSE envelope and asserts the call returns an error rather than treating the envelope as verified. The existing `TestDiscoverAttestationsOCI11*` tests now also exercise the verification hook via a passthrough stub.

### Reproduction (without this fix)

```yaml
# ClusterImagePolicy requiring SLSA provenance from a specific key:
apiVersion: policy.sigstore.dev/v1alpha1
kind: ClusterImagePolicy
metadata: { name: require-google-provenance }
spec:
  images: [{ glob: "registry.example.com/**" }]
  authorities:
  - name: google-cloud-build-key
    key: { data: "-----BEGIN PUBLIC KEY-----..." }
    attestations:
    - { name: require-provenance, predicateType: https://slsa.dev/provenance/v1 }
---
# ConfigMap enables OCI 1.1 storage discovery
data: { enable-oci11: "true" }
```

An attacker with push rights to the registry pushes:

1. A malicious image `registry.example.com/evil@sha256:<D>`.
2. An OCI 1.1 referrer manifest whose `subject` digest is `<D>`, `artifactType: "application/vnd.dsse.envelope.v1+json+in-toto"`, with a single layer whose body is a DSSE envelope:

```json
{
  "payloadType": "application/vnd.in-toto+json",
  "payload": "<base64 of an in-toto statement with predicateType https://slsa.dev/provenance/v1>",
  "signatures": [ { "sig": "ATTACKER_FORGED_SIGNATURE" } ]
}
```

The webhook returns Allowed even though the DSSE signature was never verified against the configured public key.

After this PR, the same flow returns an error from `cosign.VerifyImageAttestation` and the admission is rejected.

## Test plan

- [x] `go test ./pkg/webhook/...` — all existing tests pass, including the OCI 1.1 discovery tests
- [x] `TestValidAttestationsOCI11_RejectsForgedDSSE` — new regression test passes on this branch and FAILS on `main`
- [x] `TestProcessAttestationArtifact/DSSE_envelope_missing_payloadType` — new sub-test ensures malformed envelopes are rejected
- [x] `go build ./...` clean
- [x] `gofmt -l` clean