### PR TITLE
feat: support validating oci volume mounts

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -347,9 +347,53 @@ func (v *Validator) validatePodSpec(ctx context.Context, namespace, kind, apiVer
 		wg.Wait()
 	}
 
+	checkVolumeImages := func(vols []corev1.Volume) {
+		results := make(chan containerCheckResult, len(vols))
+		wg := new(sync.WaitGroup)
+		count := 0
+		for i, vol := range vols {
+			if vol.Image == nil || vol.Image.Reference == "" {
+				continue
+			}
+			count++
+			i := i
+			ref := vol.Image.Reference
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				fe := refOrFieldError(ref, "volumes", i)
+				if fe != nil {
+					results <- containerCheckResult{index: i, containerCheckResult: fe}
+					return
+				}
+
+				containerErrors := v.validateContainerImage(ctx, ref, namespace, "volumes", i, kind, apiVersion, labels, kc, ociremote.WithRemoteOptions(
+					remote.WithContext(ctx),
+					remote.WithAuthFromKeychain(kc),
+				))
+				results <- containerCheckResult{index: i, containerCheckResult: containerErrors}
+			}()
+		}
+		for j := 0; j < count; j++ {
+			select {
+			case <-ctx.Done():
+				errs = errs.Also(apis.ErrGeneric("context was canceled before validation completed"))
+			case result, ok := <-results:
+				if !ok {
+					errs = errs.Also(apis.ErrGeneric("results channel failed to produce a result"))
+				} else {
+					errs = errs.Also(result.containerCheckResult)
+				}
+			}
+		}
+		wg.Wait()
+	}
+
 	checkContainers(ps.InitContainers, "initContainers")
 	checkContainers(ps.Containers, "containers")
 	checkEphemeralContainers(ps.EphemeralContainers, "ephemeralContainers")
+	checkVolumeImages(ps.Volumes)
 
 	return errs
 }
@@ -1121,9 +1165,40 @@ func (v *Validator) resolvePodSpec(ctx context.Context, ps *corev1.PodSpec, opt 
 		}
 	}
 
+	resolveVolumeImages := func(vols []corev1.Volume) {
+		for i, vol := range vols {
+			if vol.Image == nil || vol.Image.Reference == "" {
+				continue
+			}
+			ref, err := name.ParseReference(vol.Image.Reference)
+			if err != nil {
+				logging.FromContext(ctx).Debugf("Unable to parse volume image reference: %v", err)
+				continue
+			}
+
+			switch {
+			case apis.IsInCreate(ctx), apis.IsInUpdate(ctx):
+				digest, err := remoteResolveDigest(ref, ociremote.WithRemoteOptions(
+					remote.WithContext(ctx),
+					remote.WithAuthFromKeychain(kc),
+				))
+				if err != nil {
+					logging.FromContext(ctx).Debugf("Unable to resolve digest %q: %v", ref.String(), err)
+					continue
+				}
+				if tagRef, ok := ref.(name.Tag); ok {
+					vols[i].Image.Reference = fmt.Sprintf("%s@%s", tagRef.Name(), digest.DigestStr())
+				} else {
+					vols[i].Image.Reference = digest.String()
+				}
+			}
+		}
+	}
+
 	resolveContainers(ps.InitContainers)
 	resolveContainers(ps.Containers)
 	resolveEphemeralContainers(ps.EphemeralContainers)
+	resolveVolumeImages(ps.Volumes)
 }
 
 // getNamespace tries to extract the namespace from the HTTPRequest

--- a/pkg/webhook/validator_test.go
+++ b/pkg/webhook/validator_test.go
@@ -687,6 +687,269 @@ func TestValidatePodSpec(t *testing.T) {
 			},
 		),
 		cvs: authorityPublicKeyCVS,
+	}, {
+		name: "volume image with digest, no error",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: digest.String(),
+					},
+				},
+			}},
+		},
+		cvs: pass,
+		customContext: config.ToContext(context.Background(),
+			&config.Config{
+				ImagePolicyConfig: &config.ImagePolicyConfig{
+					Policies: map[string]webhookcip.ClusterImagePolicy{
+						"cluster-image-policy": {
+							Images: []v1alpha1.ImagePattern{{
+								Glob: "gcr.io/*/*",
+							}},
+							Authorities: []webhookcip.Authority{
+								{
+									Key: &webhookcip.KeyRef{
+										Data:              authorityKeyCosignPubString,
+										PublicKeys:        []crypto.PublicKey{authorityKeyCosignPub},
+										HashAlgorithm:     signaturealgo.DefaultSignatureAlgorithm,
+										HashAlgorithmCode: crypto.SHA256,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+	}, {
+		name: "volume image not digest",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: tag.String(),
+					},
+				},
+			}},
+		},
+		want: &apis.FieldError{
+			Message: fmt.Sprintf("invalid value: %s must be an image digest", tag.String()),
+			Paths:   []string{"volumes[0].image"},
+		},
+		cvs: fail,
+	}, {
+		name: "volume image bad reference",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: "in@valid",
+					},
+				},
+			}},
+		},
+		want: &apis.FieldError{
+			Message: `could not parse reference: in@valid`,
+			Paths:   []string{"volumes[0].image"},
+		},
+		cvs: fail,
+	}, {
+		name: "non-image volume, no error",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "config-vol",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "my-config",
+						},
+					},
+				},
+			}},
+		},
+		cvs: pass,
+		customContext: config.ToContext(context.Background(),
+			&config.Config{
+				ImagePolicyConfig: &config.ImagePolicyConfig{
+					Policies: map[string]webhookcip.ClusterImagePolicy{
+						"cluster-image-policy": {
+							Images: []v1alpha1.ImagePattern{{
+								Glob: "gcr.io/*/*",
+							}},
+							Authorities: []webhookcip.Authority{
+								{
+									Key: &webhookcip.KeyRef{
+										Data:              authorityKeyCosignPubString,
+										PublicKeys:        []crypto.PublicKey{authorityKeyCosignPub},
+										HashAlgorithm:     signaturealgo.DefaultSignatureAlgorithm,
+										HashAlgorithmCode: crypto.SHA256,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+	}, {
+		name: "volume image empty reference, skipped",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: "",
+					},
+				},
+			}},
+		},
+		cvs: pass,
+		customContext: config.ToContext(context.Background(),
+			&config.Config{
+				ImagePolicyConfig: &config.ImagePolicyConfig{
+					Policies: map[string]webhookcip.ClusterImagePolicy{
+						"cluster-image-policy": {
+							Images: []v1alpha1.ImagePattern{{
+								Glob: "gcr.io/*/*",
+							}},
+							Authorities: []webhookcip.Authority{
+								{
+									Key: &webhookcip.KeyRef{
+										Data:              authorityKeyCosignPubString,
+										PublicKeys:        []crypto.PublicKey{authorityKeyCosignPub},
+										HashAlgorithm:     signaturealgo.DefaultSignatureAlgorithm,
+										HashAlgorithmCode: crypto.SHA256,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+	}, {
+		name: "mixed volumes, only image volumes validated",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "config-vol",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "my-config",
+						},
+					},
+				},
+			}, {
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: digest.String(),
+					},
+				},
+			}},
+		},
+		cvs: pass,
+		customContext: config.ToContext(context.Background(),
+			&config.Config{
+				ImagePolicyConfig: &config.ImagePolicyConfig{
+					Policies: map[string]webhookcip.ClusterImagePolicy{
+						"cluster-image-policy": {
+							Images: []v1alpha1.ImagePattern{{
+								Glob: "gcr.io/*/*",
+							}},
+							Authorities: []webhookcip.Authority{
+								{
+									Key: &webhookcip.KeyRef{
+										Data:              authorityKeyCosignPubString,
+										PublicKeys:        []crypto.PublicKey{authorityKeyCosignPub},
+										HashAlgorithm:     signaturealgo.DefaultSignatureAlgorithm,
+										HashAlgorithmCode: crypto.SHA256,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+	}, {
+		name: "volume image fails policy",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: digest.String(),
+					},
+				},
+			}},
+		},
+		want: func() *apis.FieldError {
+			var errs *apis.FieldError
+			fe := apis.ErrGeneric("failed policy: cluster-image-policy", "image").ViaFieldIndex("containers", 0)
+			fe.Details = fmt.Sprintf("%s signature key validation failed for authority  for %s: bad signature", digest.String(), "gcr.io/distroless/static@sha256:be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4")
+			errs = errs.Also(fe)
+			fe2 := apis.ErrGeneric("failed policy: cluster-image-policy", "image").ViaFieldIndex("volumes", 0)
+			fe2.Details = fe.Details
+			errs = errs.Also(fe2)
+			return errs
+		}(),
+		customContext: config.ToContext(context.Background(),
+			&config.Config{
+				ImagePolicyConfig: &config.ImagePolicyConfig{
+					Policies: map[string]webhookcip.ClusterImagePolicy{
+						"cluster-image-policy": {
+							Images: []v1alpha1.ImagePattern{{
+								Glob: "gcr.io/*/*",
+							}},
+							Authorities: []webhookcip.Authority{
+								{
+									Key: &webhookcip.KeyRef{
+										Data:              authorityKeyCosignPubString,
+										PublicKeys:        []crypto.PublicKey{authorityKeyCosignPub},
+										HashAlgorithm:     signaturealgo.DefaultSignatureAlgorithm,
+										HashAlgorithmCode: crypto.SHA256,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+		cvs: fail,
 	}}
 
 	for _, test := range tests {
@@ -1138,6 +1401,140 @@ func TestResolvePodSpec(t *testing.T) {
 		},
 		wc:  apis.WithinCreate,
 		rrd: resolve,
+	}, {
+		name: "volume image tag resolves to digest (in create)",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: tag.String(),
+					},
+				},
+			}},
+		},
+		want: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: digest.String(),
+					},
+				},
+			}},
+		},
+		wc:  apis.WithinCreate,
+		rrd: resolve,
+	}, {
+		name: "volume image already digest, no change",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digestWithoutTag.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: digestWithoutTag.String(),
+					},
+				},
+			}},
+		},
+		want: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digestWithoutTag.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: digestWithoutTag.String(),
+					},
+				},
+			}},
+		},
+		wc:  apis.WithinCreate,
+		rrd: resolve,
+	}, {
+		name: "volume image nil, skipped",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "config-vol",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "my-config",
+						},
+					},
+				},
+			}},
+		},
+		want: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "config-vol",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "my-config",
+						},
+					},
+				},
+			}},
+		},
+		wc:  apis.WithinCreate,
+		rrd: resolve,
+	}, {
+		name: "volume image resolution failure, gracefully skipped",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: tag.String(),
+					},
+				},
+			}},
+		},
+		want: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference: tag.String(),
+					},
+				},
+			}},
+		},
+		wc: apis.WithinCreate,
+		rrd: func(_ name.Reference, _ ...remote.Option) (name.Digest, error) {
+			return name.Digest{}, errors.New("boom")
+		},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

- Extend the admission webhook to validate OCI image references in volumes[].image fields, enforcing the same signature and attestation policies already applied to container images
- Resolve volume image tags to digests in the mutating webhook, consistent with existing container image resolution behavior

Solves: https://github.com/sigstore/policy-controller/issues/1974

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

feat: Add validation and resolution support for OCI image volume mounts

The admission webhook now validates image references in pod volume `image` sources, enforcing the same signature and attestation policies applied to container images. Volume image tags are also resolved to digests by the mutating webhook.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

## OCI Image Volume Validation

The policy controller now validates OCI image references specified in Kubernetes volume mounts (`volumes[].image.reference`) in addition to container images.

When a pod spec includes a volume with an `image` source, the admission webhook will:

- **Validate** that the image reference is a digest (not a tag)
- **Enforce** any matching `ClusterImagePolicy` against the volume image
- **Resolve** image tags to digests via the mutating webhook (on create/update)

Non-image volumes (ConfigMap, Secret, EmptyDir, etc.) are unaffected.

### Example

A pod spec with an OCI image volume:

```yaml
spec:
  containers:
    - name: app
      image: registry.example.com/app@sha256:abc123...
  volumes:
    - name: data
      image:
        reference: registry.example.com/data@sha256:def456...