### PR TITLE
Drop EOL k8s 1.31 and 1.32 versions

### DIFF
--- a/.github/workflows/kind-cluster-image-policy-no-tuf.yaml
+++ b/.github/workflows/kind-cluster-image-policy-no-tuf.yaml
@@ -33,8 +33,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.31.x
-        - v1.32.x
         - v1.33.x
         - v1.34.x
 

--- a/.github/workflows/kind-cluster-image-policy-trustroot.yaml
+++ b/.github/workflows/kind-cluster-image-policy-trustroot.yaml
@@ -33,8 +33,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.31.x
-          - v1.32.x
           - v1.33.x
           - v1.34.x
 

--- a/.github/workflows/kind-cluster-image-policy-tsa.yaml
+++ b/.github/workflows/kind-cluster-image-policy-tsa.yaml
@@ -33,8 +33,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.31.x
-          - v1.32.x
           - v1.33.x
           - v1.34.x
 

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -33,8 +33,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.31.x
-          - v1.32.x
           - v1.33.x
           - v1.34.x
 

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -33,8 +33,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.31.x
-        - v1.32.x
         - v1.33.x
         - v1.34.x
 

--- a/.github/workflows/kind-e2e-trustroot-crd.yaml
+++ b/.github/workflows/kind-e2e-trustroot-crd.yaml
@@ -33,8 +33,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.31.x
-        - v1.32.x
         - v1.33.x
         - v1.34.x
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Drop the [EOL k8s v1.31 and v1.32 releases](https://kubernetes.io/releases/#end-of-life-releases) from the e2e test CI checks. I will add new supported versions in a follow up pull request.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
