### PR TITLE
fix: log tag-to-digest resolution failures at Warn instead of Debug

### DIFF
--- a/pkg/webhook/validator.go
+++ b/pkg/webhook/validator.go
@@ -1123,7 +1123,7 @@ func (v *Validator) resolvePodSpec(ctx context.Context, ps *corev1.PodSpec, opt 
 					remote.WithAuthFromKeychain(kc),
 				))
 				if err != nil {
-					logging.FromContext(ctx).Debugf("Unable to resolve digest %q: %v", ref.String(), err)
+					logging.FromContext(ctx).Warnf("Unable to resolve digest %q: %v", ref.String(), err)
 					continue
 				}
 				// Keep the original tag and append the digest
@@ -1152,7 +1152,7 @@ func (v *Validator) resolvePodSpec(ctx context.Context, ps *corev1.PodSpec, opt 
 					remote.WithAuthFromKeychain(kc),
 				))
 				if err != nil {
-					logging.FromContext(ctx).Debugf("Unable to resolve digest %q: %v", ref.String(), err)
+					logging.FromContext(ctx).Warnf("Unable to resolve digest %q: %v", ref.String(), err)
 					continue
 				}
 				// Keep the original tag and append the digest
@@ -1183,7 +1183,7 @@ func (v *Validator) resolvePodSpec(ctx context.Context, ps *corev1.PodSpec, opt 
 					remote.WithAuthFromKeychain(kc),
 				))
 				if err != nil {
-					logging.FromContext(ctx).Debugf("Unable to resolve digest %q: %v", ref.String(), err)
+					logging.FromContext(ctx).Warnf("Unable to resolve digest %q: %v", ref.String(), err)
 					continue
 				}
 				if tagRef, ok := ref.(name.Tag); ok {


### PR DESCRIPTION
Motivation:
In the mutating webhook's resolvePodSpec, when a tag fails to resolve
to a digest (e.g. transient registry error, auth failure, or hitting
a registry rate limit), the failure is logged at Debug level and the
request is silently allowed through with the tag unresolved. The tag
then reaches the validating webhook, which rejects it with a generic
"<image> must be an image digest" error that gives no indication that
a resolution attempt was made and failed.

This is exactly what happened in #189: a user hit this error and had
no way to tell why, and a maintainer's own diagnosis in the issue
thread required telling them to raise the webhook's log level to
Debug and grep for rate-limit errors, since at the default log level
nothing about the failed resolution is recorded.

Approach:
This does not change any validation or mutation behavior — the image
that ends up on the pod, and what the validating webhook does with
it, are unchanged before and after this change. It is a pure
observability improvement: bump the three "Unable to resolve digest"
log statements in resolvePodSpec (regular containers, ephemeral
containers, and volume images) from Debugf to Warnf, matching the
severity already used for the sibling failure in the same function
("Unable to build k8schain" is logged at Warnf) and for other
recoverable-but-actionable failures elsewhere in this file (e.g. "no
matching policies for image"). This makes resolution failures visible
at the default log level without requiring operators to raise
verbosity, directly addressing the diagnostic gap from #189.

The related "Unable to parse reference" / "Unable to parse volume
image reference" log statements are left at Debug: those indicate a
malformed image string (an authoring error), not a transient
infra/registry failure, so they aren't the same class of problem and
are out of scope here.

Validation:
- go build ./... passes.
- go test ./pkg/webhook/... passes, including TestResolvePodSpec's
  "nothing changed (unable to resolve)" case, which already exercises
  this exact failure path (it asserts the pod spec is left unmutated
  when resolution fails; it does not assert on log level, so it
  passes unchanged with this diff).

Fixes #189

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>